### PR TITLE
Fixed loading of face landmark detector parameters in OpenFace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
     && tar -xvjf dlib-19.17.tar.bz2 && cd ../
 
 env:
-  - TOMCAT=~/tomcat
+  - TOMCAT=$TRAVIS_BUILD_DIR
 
 script:
   - ./tools/download_tomcat_data.sh

--- a/external/OpenFace/lib/local/FaceAnalyser/include/FaceAnalyser.h
+++ b/external/OpenFace/lib/local/FaceAnalyser/include/FaceAnalyser.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,232 +15,303 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef FACEANALYSER_H
-#define FACEANALYSER_H
+#pragma once
 
 // STL includes
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 
 // Local includes
+#include "FaceAnalyserParameters.h"
+#include "PDM.h"
+#include "SVM_dynamic_lin.h"
+#include "SVM_static_lin.h"
 #include "SVR_dynamic_lin_regressors.h"
 #include "SVR_static_lin_regressors.h"
-#include "SVM_static_lin.h"
-#include "SVM_dynamic_lin.h"
-#include "PDM.h"
-#include "FaceAnalyserParameters.h"
 
-namespace FaceAnalysis
-{
+namespace FaceAnalysis {
 
-class FaceAnalyser{
+  class FaceAnalyser {
 
-public:
+  public:
+    enum RegressorType {
+      SVR_appearance_static_linear = 0,
+      SVR_appearance_dynamic_linear = 1,
+      SVR_dynamic_geom_linear = 2,
+      SVR_combined_linear = 3,
+      SVM_linear_stat = 4,
+      SVM_linear_dyn = 5,
+      SVR_linear_static_seg = 6,
+      SVR_linear_dynamic_seg = 7
+    };
 
+    // Constructor for FaceAnalyser using the parameters structure
+    FaceAnalyser(
+        const FaceAnalysis::FaceAnalyserParameters& face_analyser_params);
 
-	enum RegressorType{ SVR_appearance_static_linear = 0, SVR_appearance_dynamic_linear = 1, SVR_dynamic_geom_linear = 2, SVR_combined_linear = 3, SVM_linear_stat = 4, SVM_linear_dyn = 5, SVR_linear_static_seg = 6, SVR_linear_dynamic_seg =7};
+    void AddNextFrame(const cv::Mat& frame,
+                      const cv::Mat_<float>& detected_landmarks,
+                      bool success,
+                      double timestamp_seconds,
+                      bool online = false);
 
-	// Constructor for FaceAnalyser using the parameters structure
-	FaceAnalyser(const FaceAnalysis::FaceAnalyserParameters& face_analyser_params);
+    double GetCurrentTimeSeconds();
 
-	void AddNextFrame(const cv::Mat& frame, const cv::Mat_<float>& detected_landmarks, bool success, double timestamp_seconds, bool online = false);
+    // Grab the current predictions about AUs from the face analyser
+    std::vector<std::pair<std::string, double>>
+    GetCurrentAUsClass() const; // AU presence
+    std::vector<std::pair<std::string, double>>
+    GetCurrentAUsReg() const; // AU intensity
+    std::vector<std::pair<std::string, double>>
+    GetCurrentAUsCombined() const; // Both presense and intensity
 
-	double GetCurrentTimeSeconds();
-	
-	// Grab the current predictions about AUs from the face analyser
-	std::vector<std::pair<std::string, double>> GetCurrentAUsClass() const; // AU presence
-	std::vector<std::pair<std::string, double>> GetCurrentAUsReg() const;   // AU intensity
-	std::vector<std::pair<std::string, double>> GetCurrentAUsCombined() const; // Both presense and intensity
+    // A standalone call for predicting AUs and computing face texture features
+    // from a static image
+    void PredictStaticAUsAndComputeFeatures(
+        const cv::Mat& frame, const cv::Mat_<float>& detected_landmarks);
 
-	// A standalone call for predicting AUs and computing face texture features from a static image
-	void PredictStaticAUsAndComputeFeatures(const cv::Mat& frame, const cv::Mat_<float>& detected_landmarks);
+    void Reset();
 
-	void Reset();
+    void GetLatestHOG(cv::Mat_<double>& hog_descriptor,
+                      int& num_rows,
+                      int& num_cols);
+    void GetLatestAlignedFace(cv::Mat& image);
 
-	void GetLatestHOG(cv::Mat_<double>& hog_descriptor, int& num_rows, int& num_cols);
-	void GetLatestAlignedFace(cv::Mat& image);
-	
-	void GetLatestNeutralHOG(cv::Mat_<double>& hog_descriptor, int& num_rows, int& num_cols);
-	
-	cv::Mat_<int> GetTriangulation();
-	
-	void GetGeomDescriptor(cv::Mat_<double>& geom_desc);
+    void GetLatestNeutralHOG(cv::Mat_<double>& hog_descriptor,
+                             int& num_rows,
+                             int& num_cols);
 
-	// Grab the names of AUs being predicted
-	std::vector<std::string> GetAUClassNames() const; // Presence
-	std::vector<std::string> GetAURegNames() const; // Intensity
+    cv::Mat_<int> GetTriangulation();
 
-	// Identify if models are static or dynamic (useful for correction and shifting)
-	std::vector<bool> GetDynamicAUClass() const; // Presence
-	std::vector<std::pair<std::string, bool>> GetDynamicAUReg() const; // Intensity
+    void GetGeomDescriptor(cv::Mat_<double>& geom_desc);
 
+    // Grab the names of AUs being predicted
+    std::vector<std::string> GetAUClassNames() const; // Presence
+    std::vector<std::string> GetAURegNames() const;   // Intensity
 
-	void ExtractAllPredictionsOfflineReg(std::vector<std::pair<std::string, std::vector<double>>>& au_predictions, 
-		std::vector<double>& confidences, std::vector<bool>& successes, std::vector<double>& timestamps, bool dynamic);
-	void ExtractAllPredictionsOfflineClass(std::vector<std::pair<std::string, std::vector<double>>>& au_predictions,
-		std::vector<double>& confidences, std::vector<bool>& successes, std::vector<double>& timestamps, bool dynamic);
+    // Identify if models are static or dynamic (useful for correction and
+    // shifting)
+    std::vector<bool> GetDynamicAUClass() const; // Presence
+    std::vector<std::pair<std::string, bool>>
+    GetDynamicAUReg() const; // Intensity
 
-	// Helper function for post-processing AU output files
-	void PostprocessOutputFile(std::string output_file);
+    void ExtractAllPredictionsOfflineReg(
+        std::vector<std::pair<std::string, std::vector<double>>>&
+            au_predictions,
+        std::vector<double>& confidences,
+        std::vector<bool>& successes,
+        std::vector<double>& timestamps,
+        bool dynamic);
+    void ExtractAllPredictionsOfflineClass(
+        std::vector<std::pair<std::string, std::vector<double>>>&
+            au_predictions,
+        std::vector<double>& confidences,
+        std::vector<bool>& successes,
+        std::vector<double>& timestamps,
+        bool dynamic);
 
-private:
+    // Helper function for post-processing AU output files
+    void PostprocessOutputFile(std::string output_file);
 
-	// Point distribution model coddesponding to the current Face Analyser
-	LandmarkDetector::PDM pdm;
+  private:
+    // Point distribution model coddesponding to the current Face Analyser
+    LandmarkDetector::PDM pdm;
 
-	// Where the predictions are kept
-	std::vector<std::pair<std::string, double>> AU_predictions_reg;
-	std::vector<std::pair<std::string, double>> AU_predictions_class;
+    // Where the predictions are kept
+    std::vector<std::pair<std::string, double>> AU_predictions_reg;
+    std::vector<std::pair<std::string, double>> AU_predictions_class;
 
-	std::vector<std::pair<std::string, double>> AU_predictions_combined;
+    std::vector<std::pair<std::string, double>> AU_predictions_combined;
 
-	// Keeping track of AU predictions over time (useful for post-processing)
-	std::vector<double> timestamps;
-	std::map<std::string, std::vector<double>> AU_predictions_reg_all_hist;
-	std::map<std::string, std::vector<double>> AU_predictions_class_all_hist;
-	std::vector<bool> valid_preds;
+    // Keeping track of AU predictions over time (useful for post-processing)
+    std::vector<double> timestamps;
+    std::map<std::string, std::vector<double>> AU_predictions_reg_all_hist;
+    std::map<std::string, std::vector<double>> AU_predictions_class_all_hist;
+    std::vector<bool> valid_preds;
 
-	int frames_tracking;
+    int frames_tracking;
 
-	// Is the AU model dynamic
-	bool dynamic;
+    // Is the AU model dynamic
+    bool dynamic;
 
-	// Cache of intermediate images
-	cv::Mat aligned_face_for_au;
-	cv::Mat aligned_face_for_output;
-	bool out_grayscale;
+    // Cache of intermediate images
+    cv::Mat aligned_face_for_au;
+    cv::Mat aligned_face_for_output;
+    bool out_grayscale;
 
-	// Private members to be used for predictions
-	// The HOG descriptor of the last frame
-	cv::Mat_<double> hog_desc_frame;
-	int num_hog_rows;
-	int num_hog_cols;
+    // Private members to be used for predictions
+    // The HOG descriptor of the last frame
+    cv::Mat_<double> hog_desc_frame;
+    int num_hog_rows;
+    int num_hog_cols;
 
-	// Keep a running median of the hog descriptors and a aligned images
-	cv::Mat_<double> hog_desc_median;
-	cv::Mat_<double> face_image_median;
+    // Keep a running median of the hog descriptors and a aligned images
+    cv::Mat_<double> hog_desc_median;
+    cv::Mat_<double> face_image_median;
 
-	// Use histograms for quick (but approximate) median computation
-	// Use the same for
-	std::vector<cv::Mat_<int> > hog_desc_hist;
+    // Use histograms for quick (but approximate) median computation
+    // Use the same for
+    std::vector<cv::Mat_<int>> hog_desc_hist;
 
-	// This is not being used at the moment as it is a bit slow
-	std::vector<cv::Mat_<int> > face_image_hist;
-	std::vector<int> face_image_hist_sum;
+    // This is not being used at the moment as it is a bit slow
+    std::vector<cv::Mat_<int>> face_image_hist;
+    std::vector<int> face_image_hist_sum;
 
-	std::vector<cv::Vec3d> head_orientations;
+    std::vector<cv::Vec3d> head_orientations;
 
-	int num_bins_hog;
-	double min_val_hog;
-	double max_val_hog;
-	std::vector<int> hog_hist_sum;
-	int view_used;
+    int num_bins_hog;
+    double min_val_hog;
+    double max_val_hog;
+    std::vector<int> hog_hist_sum;
+    int view_used;
 
-	// The geometry descriptor (rigid followed by non-rigid shape parameters from CLNF)
-	cv::Mat_<double> geom_descriptor_frame;
-	cv::Mat_<double> geom_descriptor_median;
-	
-	int geom_hist_sum;
-	cv::Mat_<int> geom_desc_hist;
-	int num_bins_geom;
-	double min_val_geom;
-	double max_val_geom;
-	
-	// Using the bounding box of previous analysed frame to determine if a reset is needed
-	cv::Rect_<double> face_bounding_box;
-	
-	// The AU predictions internally
-	std::vector<std::pair<std::string, double>> PredictCurrentAUs(int view);
-	std::vector<std::pair<std::string, double>> PredictCurrentAUsClass(int view);
+    // The geometry descriptor (rigid followed by non-rigid shape parameters
+    // from CLNF)
+    cv::Mat_<double> geom_descriptor_frame;
+    cv::Mat_<double> geom_descriptor_median;
 
-	// special step for online (rather than offline AU prediction)
-	std::vector<std::pair<std::string, double>> CorrectOnlineAUs(std::vector<std::pair<std::string, double>> predictions_orig, int view, bool dyn_shift = false, bool dyn_scale = false, bool update_track = true, bool clip_values = false);
+    int geom_hist_sum;
+    cv::Mat_<int> geom_desc_hist;
+    int num_bins_geom;
+    double min_val_geom;
+    double max_val_geom;
 
-	void Read(std::string model_loc);
+    // Using the bounding box of previous analysed frame to determine if a reset
+    // is needed
+    cv::Rect_<double> face_bounding_box;
 
-	void ReadAU(std::string au_location);
+    // The AU predictions internally
+    std::vector<std::pair<std::string, double>> PredictCurrentAUs(int view);
+    std::vector<std::pair<std::string, double>>
+    PredictCurrentAUsClass(int view);
 
-	void ReadRegressor(std::string fname, const std::vector<std::string>& au_names);
+    // special step for online (rather than offline AU prediction)
+    std::vector<std::pair<std::string, double>> CorrectOnlineAUs(
+        std::vector<std::pair<std::string, double>> predictions_orig,
+        int view,
+        bool dyn_shift = false,
+        bool dyn_scale = false,
+        bool update_track = true,
+        bool clip_values = false);
 
-	// A utility function for keeping track of approximate running medians used for AU and emotion inference using a set of histograms (the histograms are evenly spaced from min_val to max_val)
-	// Descriptor has to be a row vector
-	// TODO this duplicates some other code
-	void UpdateRunningMedian(cv::Mat_<int>& histogram, int& hist_sum, cv::Mat_<double>& median, const cv::Mat_<double>& descriptor, bool update, int num_bins, double min_val, double max_val);
-	void ExtractMedian(cv::Mat_<int>& histogram, int hist_count, cv::Mat_<double>& median, int num_bins, double min_val, double max_val);
-	
-	// The linear SVR regressors
-	SVR_static_lin_regressors AU_SVR_static_appearance_lin_regressors;
-	SVR_dynamic_lin_regressors AU_SVR_dynamic_appearance_lin_regressors;
-		
-	// The linear SVM classifiers
-	SVM_static_lin AU_SVM_static_appearance_lin;
-	SVM_dynamic_lin AU_SVM_dynamic_appearance_lin;
+    void Read(std::string model_loc);
 
-	// The AUs predicted by the model are not always 0 calibrated to a person. That is they don't always predict 0 for a neutral expression
-	// Keeping track of the predictions we can correct for this, by assuming that at least "ratio" of frames are neutral and subtract that value of prediction, only perform the correction after min_frames
-	void UpdatePredictionTrack(cv::Mat_<int>& prediction_corr_histogram, int& prediction_correction_count, 
-		std::vector<double>& correction, const std::vector<std::pair<std::string, double>>& predictions, double ratio=0.25, int num_bins = 200, double min_val = -3, double max_val = 5, int min_frames = 10);
-	void GetSampleHist(cv::Mat_<int>& prediction_corr_histogram, int prediction_correction_count, 
-		std::vector<double>& sample, double ratio, int num_bins = 200, double min_val = 0, double max_val = 5);
+    void ReadAU(std::string au_location);
 
-	void PostprocessPredictions();
+    void ReadRegressor(std::string fname,
+                       const std::vector<std::string>& au_names);
 
-	std::vector<cv::Mat_<int>> au_prediction_correction_histogram;
-	std::vector<int> au_prediction_correction_count;
+    // A utility function for keeping track of approximate running medians used
+    // for AU and emotion inference using a set of histograms (the histograms
+    // are evenly spaced from min_val to max_val) Descriptor has to be a row
+    // vector
+    // TODO this duplicates some other code
+    void UpdateRunningMedian(cv::Mat_<int>& histogram,
+                             int& hist_sum,
+                             cv::Mat_<double>& median,
+                             const cv::Mat_<double>& descriptor,
+                             bool update,
+                             int num_bins,
+                             double min_val,
+                             double max_val);
+    void ExtractMedian(cv::Mat_<int>& histogram,
+                       int hist_count,
+                       cv::Mat_<double>& median,
+                       int num_bins,
+                       double min_val,
+                       double max_val);
 
-	// Some dynamic scaling (the logic is that before the extreme versions of expression or emotion are shown,
-	// it is hard to tell the boundaries, this allows us to scale the model to the most extreme seen)
-	// They have to be view specific
-	std::vector<std::vector<double>> dyn_scaling;
-	
-	// Keeping track of predictions for summary stats
-	cv::Mat_<double> AU_prediction_track;
-	cv::Mat_<double> geom_desc_track;
+    // The linear SVR regressors
+    SVR_static_lin_regressors AU_SVR_static_appearance_lin_regressors;
+    SVR_dynamic_lin_regressors AU_SVR_dynamic_appearance_lin_regressors;
 
-	double current_time_seconds;
+    // The linear SVM classifiers
+    SVM_static_lin AU_SVM_static_appearance_lin;
+    SVM_dynamic_lin AU_SVM_dynamic_appearance_lin;
 
-	// Used for face alignment
-	cv::Mat_<int> triangulation;
-	double align_scale_au;
-	int align_width_au;
-	int align_height_au;
+    // The AUs predicted by the model are not always 0 calibrated to a person.
+    // That is they don't always predict 0 for a neutral expression Keeping
+    // track of the predictions we can correct for this, by assuming that at
+    // least "ratio" of frames are neutral and subtract that value of
+    // prediction, only perform the correction after min_frames
+    void UpdatePredictionTrack(
+        cv::Mat_<int>& prediction_corr_histogram,
+        int& prediction_correction_count,
+        std::vector<double>& correction,
+        const std::vector<std::pair<std::string, double>>& predictions,
+        double ratio = 0.25,
+        int num_bins = 200,
+        double min_val = -3,
+        double max_val = 5,
+        int min_frames = 10);
+    void GetSampleHist(cv::Mat_<int>& prediction_corr_histogram,
+                       int prediction_correction_count,
+                       std::vector<double>& sample,
+                       double ratio,
+                       int num_bins = 200,
+                       double min_val = 0,
+                       double max_val = 5);
 
-	bool align_mask;
-	double align_scale_out;
-	int align_width_out;
-	int align_height_out;
+    void PostprocessPredictions();
 
-	// Useful placeholder for renormalizing the initial frames of shorter videos
-	int max_init_frames = 3000;
-	std::vector<cv::Mat_<double>> hog_desc_frames_init;
-	std::vector<cv::Mat_<double>> geom_descriptor_frames_init;
-	std::vector<int> views;
-	bool postprocessed = false;
-	int frames_tracking_succ = 0;
+    std::vector<cv::Mat_<int>> au_prediction_correction_histogram;
+    std::vector<int> au_prediction_correction_count;
 
-};
+    // Some dynamic scaling (the logic is that before the extreme versions of
+    // expression or emotion are shown, it is hard to tell the boundaries, this
+    // allows us to scale the model to the most extreme seen) They have to be
+    // view specific
+    std::vector<std::vector<double>> dyn_scaling;
+
+    // Keeping track of predictions for summary stats
+    cv::Mat_<double> AU_prediction_track;
+    cv::Mat_<double> geom_desc_track;
+
+    double current_time_seconds;
+
+    // Used for face alignment
+    cv::Mat_<int> triangulation;
+    double align_scale_au;
+    int align_width_au;
+    int align_height_au;
+
+    bool align_mask;
+    double align_scale_out;
+    int align_width_out;
+    int align_height_out;
+
+    // Useful placeholder for renormalizing the initial frames of shorter videos
+    int max_init_frames = 3000;
+    std::vector<cv::Mat_<double>> hog_desc_frames_init;
+    std::vector<cv::Mat_<double>> geom_descriptor_frames_init;
+    std::vector<int> views;
+    bool postprocessed = false;
+    int frames_tracking_succ = 0;
+  };
   //===========================================================================
-}
-#endif // FACEANALYSER_H
+} // namespace FaceAnalysis

--- a/external/OpenFace/lib/local/FaceAnalyser/include/FaceAnalyserParameters.h
+++ b/external/OpenFace/lib/local/FaceAnalyser/include/FaceAnalyserParameters.h
@@ -85,8 +85,7 @@ namespace FaceAnalysis {
       path model_path = OpenFace_models_dir /
                         ("AU_Predictors/main_" + model_type + "_svms.txt");
       if (!exists(model_path)) {
-        throw std::runtime_error(
-            "Could not find the face analysis module to load");
+        throw runtime_error("Could not find the face analysis module to load");
       }
 
       this->model_location = model_path.string();

--- a/external/OpenFace/lib/local/LandmarkDetector/include/CNN_utils.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/CNN_utils.h
@@ -3,8 +3,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -13,50 +14,69 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef CNN_UTILS_H
-#define CNN_UTILS_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 
-using namespace std;
+namespace LandmarkDetector {
+  //===========================================================================
+  // Various CNN layers
 
-namespace LandmarkDetector
-{
-	//===========================================================================	
-	// Various CNN layers
+  // Parametric ReLU with leaky weights (separate ones per channel)
+  void PReLU(std::vector<cv::Mat_<float>>& input_output_maps,
+             cv::Mat_<float> prelu_weights);
 
-	// Parametric ReLU with leaky weights (separate ones per channel)
-	void PReLU(std::vector<cv::Mat_<float> >& input_output_maps, cv::Mat_<float> prelu_weights);
+  // The fully connected layer
+  void fully_connected(std::vector<cv::Mat_<float>>& outputs,
+                       const std::vector<cv::Mat_<float>>& input_maps,
+                       cv::Mat_<float> weights,
+                       cv::Mat_<float> biases);
 
-	// The fully connected layer
-	void fully_connected(std::vector<cv::Mat_<float> >& outputs, const std::vector<cv::Mat_<float> >& input_maps, cv::Mat_<float> weights, cv::Mat_<float> biases);
+  // Max pooling layer with parametrized stride and kernel sizes
+  void max_pooling(std::vector<cv::Mat_<float>>& outputs,
+                   const std::vector<cv::Mat_<float>>& input_maps,
+                   int stride_x,
+                   int stride_y,
+                   int kernel_size_x,
+                   int kernel_size_y);
 
-	// Max pooling layer with parametrized stride and kernel sizes
-	void max_pooling(std::vector<cv::Mat_<float> >& outputs, const std::vector<cv::Mat_<float> >& input_maps, int stride_x, int stride_y, int kernel_size_x, int kernel_size_y);
+  // Convolution using FFT optimization rather than matrix multiplication, TODO
+  // do these still work
+  void convolution_fft2(
+      std::vector<cv::Mat_<float>>& outputs,
+      const std::vector<cv::Mat_<float>>& input_maps,
+      const std::vector<std::vector<cv::Mat_<float>>>& kernels,
+      const std::vector<float>& biases,
+      std::vector<std::map<int, std::vector<cv::Mat_<double>>>>& precomp_dfts);
 
-	// Convolution using FFT optimization rather than matrix multiplication, TODO do these still work
-	void convolution_fft2(std::vector<cv::Mat_<float> >& outputs, const std::vector<cv::Mat_<float> >& input_maps, const std::vector<std::vector<cv::Mat_<float> > >& kernels, const std::vector<float >& biases, vector<map<int, vector<cv::Mat_<double> > > >& precomp_dfts);
-	
-	// Convolution using matrix multiplication and OpenBLAS optimization, can also provide a pre-allocated im2col result for faster processing
-	void convolution_direct_blas(std::vector<cv::Mat_<float> >& outputs, const std::vector<cv::Mat_<float> >& input_maps, const cv::Mat_<float>& weight_matrix, int height_k, int width_k, cv::Mat_<float>& pre_alloc_im2col);
-}
-#endif // CNN_UTILS_H
+  // Convolution using matrix multiplication and OpenBLAS optimization, can also
+  // provide a pre-allocated im2col result for faster processing
+  void convolution_direct_blas(std::vector<cv::Mat_<float>>& outputs,
+                               const std::vector<cv::Mat_<float>>& input_maps,
+                               const cv::Mat_<float>& weight_matrix,
+                               int height_k,
+                               int width_k,
+                               cv::Mat_<float>& pre_alloc_im2col);
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/FaceDetectorMTCNN.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/FaceDetectorMTCNN.h
@@ -3,8 +3,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -13,26 +14,28 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef FACE_DETECTOR_MTCNN_H
-#define FACE_DETECTOR_MTCNN_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
@@ -40,96 +43,105 @@
 // System includes
 #include <vector>
 
-using namespace std;
+namespace LandmarkDetector {
+  class CNN {
+  public:
+    //==========================================
 
-namespace LandmarkDetector
-{
-	class CNN
-	{
-	public:
+    // Default constructor
+    CNN() { ; }
 
-		//==========================================
+    // Copy constructor
+    CNN(const CNN& other);
 
-		// Default constructor
-		CNN() { ; }
+    // Given an image apply a CNN on it, the boolean direct controls if direct
+    // convolution is used (through matrix multiplication) or an FFT
+    // optimization
+    std::vector<cv::Mat_<float>> Inference(const cv::Mat& input_img,
+                                           bool direct = true,
+                                           bool thread_safe = false);
 
-		// Copy constructor
-		CNN(const CNN& other);
+    // Reading in the model
+    void Read(const std::string& location);
 
-		// Given an image apply a CNN on it, the boolean direct controls if direct convolution is used (through matrix multiplication) or an FFT optimization
-		std::vector<cv::Mat_<float> > Inference(const cv::Mat& input_img, bool direct = true, bool thread_safe = false);
+    // Clearing precomputed DFTs
+    void ClearPrecomp();
 
-		// Reading in the model
-		void Read(const string& location);
+    size_t NumberOfLayers() { return cnn_layer_types.size(); }
 
-		// Clearing precomputed DFTs
-		void ClearPrecomp();
+  private:
+    //==========================================
+    // Convolutional Neural Network
 
-		size_t NumberOfLayers() { return cnn_layer_types.size(); }
+    // CNN layers
+    // Layer -> Weight matrix
+    std::vector<cv::Mat_<float>> cnn_convolutional_layers_weights;
 
-	private:
-		//==========================================
-		// Convolutional Neural Network
+    // Keeping some pre-allocated im2col data as malloc is a significant time
+    // cost (not thread safe though)
+    std::vector<cv::Mat_<float>> conv_layer_pre_alloc_im2col;
 
-		// CNN layers
-		// Layer -> Weight matrix
-		vector<cv::Mat_<float> > cnn_convolutional_layers_weights;
+    // Layer -> kernel -> input std::maps
+    std::vector<std::vector<std::vector<cv::Mat_<float>>>>
+        cnn_convolutional_layers;
+    std::vector<std::vector<float>> cnn_convolutional_layers_bias;
+    // Layer matrix + bas
+    std::vector<cv::Mat_<float>> cnn_fully_connected_layers_weights;
+    std::vector<cv::Mat_<float>> cnn_fully_connected_layers_biases;
+    std::vector<cv::Mat_<float>> cnn_prelu_layer_weights;
+    std::vector<std::tuple<int, int, int, int>> cnn_max_pooling_layers;
 
-		// Keeping some pre-allocated im2col data as malloc is a significant time cost (not thread safe though)
-		vector<cv::Mat_<float> > conv_layer_pre_alloc_im2col;
+    // Precomputations for faster convolution
+    std::vector<std::vector<std::map<int, std::vector<cv::Mat_<double>>>>>
+        cnn_convolutional_layers_dft;
 
-		// Layer -> kernel -> input maps
-		vector<vector<vector<cv::Mat_<float> > > > cnn_convolutional_layers;
-		vector<vector<float > > cnn_convolutional_layers_bias;
-		// Layer matrix + bas
-		vector<cv::Mat_<float> >  cnn_fully_connected_layers_weights;
-		vector<cv::Mat_<float> > cnn_fully_connected_layers_biases;
-		vector<cv::Mat_<float> >  cnn_prelu_layer_weights;
-		vector<std::tuple<int, int, int, int> > cnn_max_pooling_layers;
+    // CNN: 0 - convolutional, 1 - max pooling, 2 - fully connected, 3 - prelu,
+    // 4 - sigmoid
+    std::vector<int> cnn_layer_types;
+  };
+  //===========================================================================
+  //
+  // Checking if landmark detection was successful using an SVR regressor
+  // Using multiple validators trained add different views
+  // The regressor outputs -1 for ideal alignment and 1 for worst alignment
+  //===========================================================================
+  class FaceDetectorMTCNN {
 
-		// Precomputations for faster convolution
-		vector<vector<map<int, vector<cv::Mat_<double> > > > > cnn_convolutional_layers_dft;
+  public:
+    // Default constructor
+    FaceDetectorMTCNN() { ; }
 
-		// CNN: 0 - convolutional, 1 - max pooling, 2 - fully connected, 3 - prelu, 4 - sigmoid
-		vector<int > cnn_layer_types;
-	};
-	//===========================================================================
-	//
-	// Checking if landmark detection was successful using an SVR regressor
-	// Using multiple validators trained add different views
-	// The regressor outputs -1 for ideal alignment and 1 for worst alignment
-	//===========================================================================
-	class FaceDetectorMTCNN
-	{
+    FaceDetectorMTCNN(const std::string& location);
 
-	public:
+    // Copy constructor
+    FaceDetectorMTCNN(const FaceDetectorMTCNN& other);
 
-		// Default constructor
-		FaceDetectorMTCNN() { ; }
+    // Given an image, orientation and detected landmarks output the result of
+    // the appropriate regressor
+    bool DetectFaces(std::vector<cv::Rect_<float>>& o_regions,
+                     const cv::Mat& input_img,
+                     std::vector<float>& o_confidences,
+                     int min_face = 60,
+                     float t1 = 0.6,
+                     float t2 = 0.7,
+                     float t3 = 0.7);
 
-		FaceDetectorMTCNN(const string& location);
+    // Reading in the model
+    void Read(const std::string& location);
 
-		// Copy constructor
-		FaceDetectorMTCNN(const FaceDetectorMTCNN& other);
+    // Indicate if the model has been read in
+    bool empty() {
+      return PNet.NumberOfLayers() == 0 || RNet.NumberOfLayers() == 0 ||
+             ONet.NumberOfLayers() == 0;
+    };
 
-		// Given an image, orientation and detected landmarks output the result of the appropriate regressor
-		bool DetectFaces(vector<cv::Rect_<float> >& o_regions, const cv::Mat& input_img, std::vector<float>& o_confidences, int min_face = 60, float t1 = 0.6, float t2 = 0.7, float t3 = 0.7);
+  private:
+    //==========================================
+    // Components of the model
 
-		// Reading in the model
-		void Read(const string& location);
+    CNN PNet;
+    CNN RNet;
+    CNN ONet;
+  };
 
-		// Indicate if the model has been read in
-		bool empty() { return PNet.NumberOfLayers() == 0 || RNet.NumberOfLayers() == 0 || ONet.NumberOfLayers() == 0; };
-
-	private:
-		//==========================================
-		// Components of the model
-
-		CNN PNet;
-		CNN RNet;
-		CNN ONet;
-		
-	};
-
-}
-#endif // FACE_DETECTOR_MTCNN_H
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkCoreIncludes.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkCoreIncludes.h
@@ -33,12 +33,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef LANDMARK_CORE_INCLUDES_H
-#define LANDMARK_CORE_INCLUDES_H
+#pragma once
 
 #include "LandmarkDetectorModel.h"
 #include "LandmarkDetectorFunc.h"
 #include "LandmarkDetectorParameters.h"
 #include "LandmarkDetectorUtils.h"
-
-#endif // LANDMARK_CORE_INCLUDES_H

--- a/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectionValidator.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectionValidator.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,26 +15,28 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef LANDMARK_DETECTION_VALIDATOR_H
-#define LANDMARK_DETECTION_VALIDATOR_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
@@ -44,74 +47,74 @@
 // Local includes
 #include "PAW.h"
 
-using namespace std;
 
-namespace LandmarkDetector
-{
-//===========================================================================
-//
-// Checking if landmark detection was successful using a CNN
-// Using multiple validators trained add different views
-// The regressor outputs 1 for ideal alignment and 0 for worst alignment
-//===========================================================================
-class DetectionValidator
-{
-		
-public:    
-	
-	// The orientations of each of the landmark detection validator
-	vector<cv::Vec3d> orientations;
+namespace LandmarkDetector {
+  using namespace std;
+  //===========================================================================
+  //
+  // Checking if landmark detection was successful using a CNN
+  // Using multiple validators trained add different views
+  // The regressor outputs 1 for ideal alignment and 0 for worst alignment
+  //===========================================================================
+  class DetectionValidator {
 
-	// Piecewise affine warps to the reference shape (per orientation)
-	vector<PAW>     paws;
+  public:
+    // The orientations of each of the landmark detection validator
+    vector<cv::Vec3d> orientations;
 
-	//==========================================
-	// Convolutional Neural Network
+    // Piecewise affine warps to the reference shape (per orientation)
+    vector<PAW> paws;
 
-	// CNN layers for each view
-	// view -> layer
-	vector<vector<vector<vector<cv::Mat_<float> > > > > cnn_convolutional_layers;
-	vector<vector<cv::Mat_<float> > > cnn_convolutional_layers_weights;
-	vector<vector<cv::Mat_<float> > > cnn_convolutional_layers_im2col_precomp;
+    //==========================================
+    // Convolutional Neural Network
 
-	vector< vector<int> > cnn_subsampling_layers;
-	vector< vector<cv::Mat_<float> > > cnn_fully_connected_layers_weights;
-	vector< vector<cv::Mat_<float>  > > cnn_fully_connected_layers_biases;
-	// NEW CNN: 0 - convolutional, 1 - max pooling (2x2 stride 2), 2 - fully connected, 3 - relu, 4 - sigmoid
-	vector<vector<int> > cnn_layer_types;
-	
-	//==========================================
+    // CNN layers for each view
+    // view -> layer
+    vector<vector<vector<vector<cv::Mat_<float>>>>> cnn_convolutional_layers;
+    vector<vector<cv::Mat_<float>>> cnn_convolutional_layers_weights;
+    vector<vector<cv::Mat_<float>>> cnn_convolutional_layers_im2col_precomp;
 
-	// Normalisation for face validation
-	vector<cv::Mat_<float> > mean_images;
-	vector<cv::Mat_<float> > standard_deviations;
+    vector<vector<int>> cnn_subsampling_layers;
+    vector<vector<cv::Mat_<float>>> cnn_fully_connected_layers_weights;
+    vector<vector<cv::Mat_<float>>> cnn_fully_connected_layers_biases;
+    // NEW CNN: 0 - convolutional, 1 - max pooling (2x2 stride 2), 2 - fully
+    // connected, 3 - relu, 4 - sigmoid
+    vector<vector<int>> cnn_layer_types;
 
-	// Default constructor
-	DetectionValidator(){;}
+    //==========================================
 
-	// Copy constructor
-	DetectionValidator(const DetectionValidator& other);
+    // Normalisation for face validation
+    vector<cv::Mat_<float>> mean_images;
+    vector<cv::Mat_<float>> standard_deviations;
 
-	// Given an image, orientation and detected landmarks output the result of the appropriate regressor
-	float Check(const cv::Vec3d& orientation, const cv::Mat_<uchar>& intensity_img, cv::Mat_<float>& detected_landmarks);
+    // Default constructor
+    DetectionValidator() { ; }
 
-	// Reading in the model
-	void Read(string location);
-			
-	// Getting the closest view center based on orientation
-	int GetViewId(const cv::Vec3d& orientation) const;
+    // Copy constructor
+    DetectionValidator(const DetectionValidator& other);
 
-private:
+    // Given an image, orientation and detected landmarks output the result of
+    // the appropriate regressor
+    float Check(const cv::Vec3d& orientation,
+                const cv::Mat_<uchar>& intensity_img,
+                cv::Mat_<float>& detected_landmarks);
 
-	// The actual regressor application on the image
+    // Reading in the model
+    void Read(string location);
 
-	// Convolutional Neural Network
-	double CheckCNN(const cv::Mat_<float>& warped_img, int view_id);
+    // Getting the closest view center based on orientation
+    int GetViewId(const cv::Vec3d& orientation) const;
 
-	// A normalisation helper
-	void NormaliseWarpedToVector(const cv::Mat_<float>& warped_img, cv::Mat_<float>& feature_vec, int view_id);
+  private:
+    // The actual regressor application on the image
 
-};
+    // Convolutional Neural Network
+    double CheckCNN(const cv::Mat_<float>& warped_img, int view_id);
 
-}
-#endif // LANDMARK_DETECTION_VALIDATOR_H
+    // A normalisation helper
+    void NormaliseWarpedToVector(const cv::Mat_<float>& warped_img,
+                                 cv::Mat_<float>& feature_vec,
+                                 int view_id);
+  };
+
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorFunc.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorFunc.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,68 +15,88 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
 //  Header for all external CLM/CLNF/CE-CLM methods of interest to the user
 //
 //
-#ifndef LANDMARK_DETECTOR_FUNC_H
-#define LANDMARK_DETECTOR_FUNC_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 
+#include <LandmarkDetectorModel.h>
 #include <LandmarkDetectorParameters.h>
 #include <LandmarkDetectorUtils.h>
-#include <LandmarkDetectorModel.h>
 
-using namespace std;
+namespace LandmarkDetector {
 
-namespace LandmarkDetector
-{
+  //================================================================================================================
+  // Landmark detection in videos, need to provide an image and model parameters
+  // (default values work well) Optionally can provide a bounding box from which
+  // to start tracking Can also optionally pass a grayscale image if it has
+  // already been computed to speed things up a bit
+  //================================================================================================================
+  bool DetectLandmarksInVideo(const cv::Mat& rgb_image,
+                              CLNF& clnf_model,
+                              FaceModelParameters& params,
+                              cv::Mat& grayscale_image);
+  bool DetectLandmarksInVideo(const cv::Mat& rgb_image,
+                              const cv::Rect_<double> bounding_box,
+                              CLNF& clnf_model,
+                              FaceModelParameters& params,
+                              cv::Mat& grayscale_image);
 
-	//================================================================================================================
-	// Landmark detection in videos, need to provide an image and model parameters (default values work well)
-	// Optionally can provide a bounding box from which to start tracking
-	// Can also optionally pass a grayscale image if it has already been computed to speed things up a bit
-	//================================================================================================================
-	bool DetectLandmarksInVideo(const cv::Mat &rgb_image, CLNF& clnf_model, FaceModelParameters& params, cv::Mat &grayscale_image);
-	bool DetectLandmarksInVideo(const cv::Mat &rgb_image, const cv::Rect_<double> bounding_box, CLNF& clnf_model, FaceModelParameters& params, cv::Mat &grayscale_image);
+  //================================================================================================================
+  // Landmark detection in image, need to provide an image and optionally CLNF
+  // model together with parameters (default values work well) Optionally can
+  // provide a bounding box in which detection is performed (this is useful if
+  // multiple faces are to be detected in images) Can also optionally pass a
+  // grayscale image if it has already been computed to speed things up a bit
+  //================================================================================================================
+  bool DetectLandmarksInImage(const cv::Mat& rgb_image,
+                              CLNF& clnf_model,
+                              FaceModelParameters& params,
+                              cv::Mat& grayscale_image);
+  // Providing a bounding box
+  bool DetectLandmarksInImage(const cv::Mat& rgb_image,
+                              const cv::Rect_<double> bounding_box,
+                              CLNF& clnf_model,
+                              FaceModelParameters& params,
+                              cv::Mat& grayscale_image);
 
-	//================================================================================================================
-	// Landmark detection in image, need to provide an image and optionally CLNF model together with parameters (default values work well)
-	// Optionally can provide a bounding box in which detection is performed (this is useful if multiple faces are to be detected in images)
-	// Can also optionally pass a grayscale image if it has already been computed to speed things up a bit
-	//================================================================================================================
-	bool DetectLandmarksInImage(const cv::Mat &rgb_image, CLNF& clnf_model, FaceModelParameters& params, cv::Mat &grayscale_image);
-	// Providing a bounding box
-	bool DetectLandmarksInImage(const cv::Mat &rgb_image, const cv::Rect_<double> bounding_box, CLNF& clnf_model, FaceModelParameters& params, cv::Mat &grayscale_image);
+  //================================================================
+  // Helper function for getting head pose from CLNF parameters
 
-	//================================================================
-	// Helper function for getting head pose from CLNF parameters
+  // Return the current estimate of the head pose in world coordinates with
+  // camera at origin (0,0,0) The format returned is [Tx, Ty, Tz, Eul_x, Eul_y,
+  // Eul_z]
+  cv::Vec6f
+  GetPose(const CLNF& clnf_model, float fx, float fy, float cx, float cy);
 
-	// Return the current estimate of the head pose in world coordinates with camera at origin (0,0,0)
-	// The format returned is [Tx, Ty, Tz, Eul_x, Eul_y, Eul_z]
-	cv::Vec6f GetPose(const CLNF& clnf_model, float fx, float fy, float cx, float cy);
-
-	// Return the current estimate of the head pose in world coordinates with camera at origin (0,0,0), but with rotation representing if the head is looking at the camera
-	// The format returned is [Tx, Ty, Tz, Eul_x, Eul_y, Eul_z]
-	cv::Vec6f GetPoseWRTCamera(const CLNF& clnf_model, float fx, float fy, float cx, float cy);
-}
-#endif // LANDMARK_DETECTOR_FUNC_H
+  // Return the current estimate of the head pose in world coordinates with
+  // camera at origin (0,0,0), but with rotation representing if the head is
+  // looking at the camera The format returned is [Tx, Ty, Tz, Eul_x, Eul_y,
+  // Eul_z]
+  cv::Vec6f GetPoseWRTCamera(
+      const CLNF& clnf_model, float fx, float fy, float cx, float cy);
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorModel.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorModel.h
@@ -53,199 +53,200 @@
 #include "Patch_experts.h"
 
 namespace LandmarkDetector {
-using namespace std;
+  using namespace std;
 
-// A main class containing all the modules required for landmark detection
-// Face shape model
-// Patch experts
-// Optimization techniques
-class CLNF {
+  // A main class containing all the modules required for landmark detection
+  // Face shape model
+  // Patch experts
+  // Optimization techniques
+  class CLNF {
 
-public:
+  public:
+    //===========================================================================
+    // Member variables that contain the model description
+
+    // The linear 3D Point Distribution Model
+    PDM pdm;
+    // The set of patch experts
+    Patch_experts patch_experts;
+
+    // The local and global parameters describing the current model instance
+    // (current landmark detections)
+
+    // Local parameters describing the non-rigid shape
+    cv::Mat_<float> params_local;
+
+    // Global parameters describing the rigid shape [scale, euler_x, euler_y,
+    // euler_z, tx, ty]
+    cv::Vec6f params_global;
+
+    // A collection of hierarchical CLNF models that can be used for refinement
+    vector<CLNF> hierarchical_models;
+    vector<string> hierarchical_model_names;
+    vector<vector<pair<int, int>>> hierarchical_mapping;
+    vector<FaceModelParameters> hierarchical_params;
+
+    //==================== Helpers for face detection and landmark detection
+    // validation =========================================
+
+    // TODO these should be static, and loading should be made easier
+
+    // Haar cascade classifier for face detection
+    cv::CascadeClassifier face_detector_HAAR;
+    string haar_face_detector_location;
+
+    // A HOG SVM-struct based face detector
+    dlib::frontal_face_detector face_detector_HOG;
+
+    FaceDetectorMTCNN face_detector_MTCNN;
+    string mtcnn_face_detector_location;
+
+    // Validate if the detected landmarks are correct using an SVR regressor
+    DetectionValidator landmark_validator;
+
+    // Indicating if landmark detection succeeded (based on SVR validator)
+    bool detection_success;
+
+    // Indicating if the tracking has been initialised (for video based
+    // tracking)
+    bool tracking_initialised;
+
+    // The actual output of the regressor (-1 is perfect detection 1 is worst
+    // detection)
+    float detection_certainty;
+
+    // Indicator if eye model is there for eye detection
+    bool eye_model;
+
+    // the triangulation per each view (for drawing purposes only)
+    vector<cv::Mat_<int>> triangulations;
+
+    //===========================================================================
+    // Member variables that retain the state of the tracking (reflecting the
+    // state of the lastly tracked (detected) image
+
+    // Lastly detect 2D model shape [x1,x2,...xn,y1,...yn]
+    cv::Mat_<float> detected_landmarks;
+
+    // The landmark detection likelihoods (combined and per patch expert)
+    float model_likelihood;
+    cv::Mat_<float> landmark_likelihoods;
+
+    // Keeping track of how many frames the tracker has failed in so far when
+    // tracking in videos This is useful for knowing when to initialise and
+    // reinitialise tracking
+    int failures_in_a_row;
+
+    // A template of a face that last succeeded with tracking (useful for large
+    // motions in video)
+    cv::Mat_<uchar> face_template;
+
+    // Useful when resetting or initialising the model closer to a specific
+    // location (when multiple faces are present)
+    cv::Point_<double> preference_det;
+
+    // Tracking which view was used last
+    int view_used;
+
+    // See if the model was read in correctly
+    bool loaded_successfully;
+
+    // A default constructor
+    CLNF();
+
+    // Constructor from a model file
+    CLNF(string fname);
+
+    // Copy constructor (makes a deep copy of the detector)
+    CLNF(const CLNF& other);
+
+    // Assignment operator for lvalues (makes a deep copy of the detector)
+    CLNF& operator=(const CLNF& other);
+
+    // Empty Destructor	as the memory of every object will be managed by the
+    // corresponding libraries (no pointers)
+    ~CLNF() {}
+
+    // Move constructor
+    CLNF(const CLNF&& other);
+
+    // Assignment operator for rvalues
+    CLNF& operator=(const CLNF&& other);
+
+    // Does the actual work - landmark detection
+    bool DetectLandmarks(const cv::Mat_<uchar>& image,
+                         FaceModelParameters& params);
+
+    // Gets the shape of the current detected landmarks in camera space (given
+    // camera calibration) Can only be called after a call to
+    // DetectLandmarksInVideo or DetectLandmarksInImage
+    cv::Mat_<float> GetShape(float fx, float fy, float cx, float cy) const;
+
+    // A utility bounding box function
+    cv::Rect_<float> GetBoundingBox() const;
+
+    // Get the currently non-self occluded landmarks
+    cv::Mat_<int> GetVisibilities() const;
+
+    // Reset the model (useful if we want to completelly reinitialise, or we
+    // want to track another video)
+    void Reset();
+
+    // Reset the model, choosing the face nearest (x,y) where x and y are
+    // between 0 and 1.
+    void Reset(double x, double y);
+
+    // Reading the model in
+    void Read(string name);
+
+  private:
+    // Helper reading function
+    bool Read_CLNF(string clnf_location);
+
+    // the speedup of RLMS using precalculated KDE responses (described in
+    // Saragih 2011 RLMS paper)
+    map<int, cv::Mat_<float>> kde_resp_precalc;
+
+    // The model fitting: patch response computation and optimisation steps
+    bool Fit(const cv::Mat_<float>& intensity_image,
+             const std::vector<int>& window_sizes,
+             const FaceModelParameters& parameters);
+
+    // Mean shift computation that uses precalculated kernel density estimators
+    // (the one actually used)
+    void NonVectorisedMeanShift_precalc_kde(
+        cv::Mat_<float>& out_mean_shifts,
+        const vector<cv::Mat_<float>>& patch_expert_responses,
+        const cv::Mat_<float>& dxs,
+        const cv::Mat_<float>& dys,
+        int resp_size,
+        float a,
+        int scale,
+        int view_id,
+        map<int, cv::Mat_<float>>& mean_shifts);
+
+    // The actual model optimisation (update step), returns the model likelihood
+    float NU_RLMS(cv::Vec6f& final_global,
+                  cv::Mat_<float>& final_local,
+                  const vector<cv::Mat_<float>>& patch_expert_responses,
+                  const cv::Vec6f& initial_global,
+                  const cv::Mat_<float>& initial_local,
+                  const cv::Mat_<float>& base_shape,
+                  const cv::Matx22f& sim_img_to_ref,
+                  const cv::Matx22f& sim_ref_to_img,
+                  int resp_size,
+                  int view_idx,
+                  bool rigid,
+                  int scale,
+                  cv::Mat_<float>& landmark_lhoods,
+                  const FaceModelParameters& parameters,
+                  bool compute_lhood);
+
+    // Generating the weight matrix for the Weighted least squares
+    void GetWeightMatrix(cv::Mat_<float>& WeightMatrix,
+                         int scale,
+                         int view_id,
+                         const FaceModelParameters& parameters);
+  };
   //===========================================================================
-  // Member variables that contain the model description
-
-  // The linear 3D Point Distribution Model
-  PDM pdm;
-  // The set of patch experts
-  Patch_experts patch_experts;
-
-  // The local and global parameters describing the current model instance
-  // (current landmark detections)
-
-  // Local parameters describing the non-rigid shape
-  cv::Mat_<float> params_local;
-
-  // Global parameters describing the rigid shape [scale, euler_x, euler_y,
-  // euler_z, tx, ty]
-  cv::Vec6f params_global;
-
-  // A collection of hierarchical CLNF models that can be used for refinement
-  vector<CLNF> hierarchical_models;
-  vector<string> hierarchical_model_names;
-  vector<vector<pair<int, int>>> hierarchical_mapping;
-  vector<FaceModelParameters> hierarchical_params;
-
-  //==================== Helpers for face detection and landmark detection
-  // validation =========================================
-
-  // TODO these should be static, and loading should be made easier
-
-  // Haar cascade classifier for face detection
-  cv::CascadeClassifier face_detector_HAAR;
-  string haar_face_detector_location;
-
-  // A HOG SVM-struct based face detector
-  dlib::frontal_face_detector face_detector_HOG;
-
-  FaceDetectorMTCNN face_detector_MTCNN;
-  string mtcnn_face_detector_location;
-
-  // Validate if the detected landmarks are correct using an SVR regressor
-  DetectionValidator landmark_validator;
-
-  // Indicating if landmark detection succeeded (based on SVR validator)
-  bool detection_success;
-
-  // Indicating if the tracking has been initialised (for video based tracking)
-  bool tracking_initialised;
-
-  // The actual output of the regressor (-1 is perfect detection 1 is worst
-  // detection)
-  float detection_certainty;
-
-  // Indicator if eye model is there for eye detection
-  bool eye_model;
-
-  // the triangulation per each view (for drawing purposes only)
-  vector<cv::Mat_<int>> triangulations;
-
-  //===========================================================================
-  // Member variables that retain the state of the tracking (reflecting the
-  // state of the lastly tracked (detected) image
-
-  // Lastly detect 2D model shape [x1,x2,...xn,y1,...yn]
-  cv::Mat_<float> detected_landmarks;
-
-  // The landmark detection likelihoods (combined and per patch expert)
-  float model_likelihood;
-  cv::Mat_<float> landmark_likelihoods;
-
-  // Keeping track of how many frames the tracker has failed in so far when
-  // tracking in videos This is useful for knowing when to initialise and
-  // reinitialise tracking
-  int failures_in_a_row;
-
-  // A template of a face that last succeeded with tracking (useful for large
-  // motions in video)
-  cv::Mat_<uchar> face_template;
-
-  // Useful when resetting or initialising the model closer to a specific
-  // location (when multiple faces are present)
-  cv::Point_<double> preference_det;
-
-  // Tracking which view was used last
-  int view_used;
-
-  // See if the model was read in correctly
-  bool loaded_successfully;
-
-  // A default constructor
-  CLNF();
-
-  // Constructor from a model file
-  CLNF(string fname);
-
-  // Copy constructor (makes a deep copy of the detector)
-  CLNF(const CLNF &other);
-
-  // Assignment operator for lvalues (makes a deep copy of the detector)
-  CLNF &operator=(const CLNF &other);
-
-  // Empty Destructor	as the memory of every object will be managed by the
-  // corresponding libraries (no pointers)
-  ~CLNF() {}
-
-  // Move constructor
-  CLNF(const CLNF &&other);
-
-  // Assignment operator for rvalues
-  CLNF &operator=(const CLNF &&other);
-
-  // Does the actual work - landmark detection
-  bool DetectLandmarks(const cv::Mat_<uchar> &image,
-                       FaceModelParameters &params);
-
-  // Gets the shape of the current detected landmarks in camera space (given
-  // camera calibration) Can only be called after a call to
-  // DetectLandmarksInVideo or DetectLandmarksInImage
-  cv::Mat_<float> GetShape(float fx, float fy, float cx, float cy) const;
-
-  // A utility bounding box function
-  cv::Rect_<float> GetBoundingBox() const;
-
-  // Get the currently non-self occluded landmarks
-  cv::Mat_<int> GetVisibilities() const;
-
-  // Reset the model (useful if we want to completelly reinitialise, or we want
-  // to track another video)
-  void Reset();
-
-  // Reset the model, choosing the face nearest (x,y) where x and y are between
-  // 0 and 1.
-  void Reset(double x, double y);
-
-  // Reading the model in
-  void Read(string name);
-
-private:
-  // Helper reading function
-  bool Read_CLNF(string clnf_location);
-
-  // the speedup of RLMS using precalculated KDE responses (described in Saragih
-  // 2011 RLMS paper)
-  map<int, cv::Mat_<float>> kde_resp_precalc;
-
-  // The model fitting: patch response computation and optimisation steps
-  bool Fit(const cv::Mat_<float> &intensity_image,
-           const std::vector<int> &window_sizes,
-           const FaceModelParameters &parameters);
-
-  // Mean shift computation that uses precalculated kernel density estimators
-  // (the one actually used)
-  void NonVectorisedMeanShift_precalc_kde(
-      cv::Mat_<float> &out_mean_shifts,
-      const vector<cv::Mat_<float>> &patch_expert_responses,
-      const cv::Mat_<float> &dxs,
-      const cv::Mat_<float> &dys,
-      int resp_size,
-      float a,
-      int scale,
-      int view_id,
-      map<int, cv::Mat_<float>> &mean_shifts);
-
-  // The actual model optimisation (update step), returns the model likelihood
-  float NU_RLMS(cv::Vec6f &final_global,
-                cv::Mat_<float> &final_local,
-                const vector<cv::Mat_<float>> &patch_expert_responses,
-                const cv::Vec6f &initial_global,
-                const cv::Mat_<float> &initial_local,
-                const cv::Mat_<float> &base_shape,
-                const cv::Matx22f &sim_img_to_ref,
-                const cv::Matx22f &sim_ref_to_img,
-                int resp_size,
-                int view_idx,
-                bool rigid,
-                int scale,
-                cv::Mat_<float> &landmark_lhoods,
-                const FaceModelParameters &parameters,
-                bool compute_lhood);
-
-  // Generating the weight matrix for the Weighted least squares
-  void GetWeightMatrix(cv::Mat_<float> &WeightMatrix,
-                       int scale,
-                       int view_id,
-                       const FaceModelParameters &parameters);
-};
-//===========================================================================
 } // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorParameters.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorParameters.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,107 +15,116 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
 //  Parameters of the CE-CLM, CLNF, and CLM trackers
-#ifndef LANDMARK_DETECTOR_PARAM_H
-#define LANDMARK_DETECTOR_PARAM_H
+#pragma once
 
+#include <boost/filesystem.hpp>
+#include <string>
 #include <vector>
 
-using namespace std;
+namespace LandmarkDetector {
+  using boost::filesystem::path;
 
-namespace LandmarkDetector
-{
+  class FaceModelParameters {
 
-struct FaceModelParameters
-{
+  public:
+    // Path to OpenFace models
+    std::string OpenFace_models_dir =
+        (path(getenv("TOMCAT")) / "data/OpenFace_models").string();
 
-	// A number of RLMS or NU-RLMS iterations
-	int num_optimisation_iteration;
-	
-	// Should pose be limited to 180 degrees frontal
-	bool limit_pose;
-	
-	// Should face validation be done
-	bool validate_detections;
+    // A number of RLMS or NU-RLMS iterations
+    int num_optimisation_iteration;
 
-	// Landmark detection validator boundary for correct detection, the regressor output 1 (perfect alignment) 0 (bad alignment), 
-	float validation_boundary;
+    // Should pose be limited to 180 degrees frontal
+    bool limit_pose;
 
-	// Used when tracking is going well
-	vector<int> window_sizes_small;
+    // Should face validation be done
+    bool validate_detections;
 
-	// Used when initialising or tracking fails
-	vector<int> window_sizes_init;
-	
-	// Used for the current frame
-	vector<int> window_sizes_current;
-	
-	// How big is the tracking template that helps with large motions
-	float face_template_scale;	
-	bool use_face_template;
+    // Landmark detection validator boundary for correct detection, the
+    // regressor output 1 (perfect alignment) 0 (bad alignment),
+    float validation_boundary;
 
-	// Where to load the model from
-	string model_location;
-	
-	// this is used for the smooting of response maps (KDE sigma)
-	float sigma;
+    // Used when tracking is going well
+    std::vector<int> window_sizes_small;
 
-	float reg_factor;	// weight put to regularisation
-	float weight_factor; // factor for weighted least squares
+    // Used when initialising or tracking fails
+    std::vector<int> window_sizes_init;
 
-	// should multiple views be considered during reinit
-	bool multi_view;
-	
-	// Based on model location, this affects the parameter settings
-	enum LandmarkDetector { CLM_DETECTOR, CLNF_DETECTOR, CECLM_DETECTOR };
-	LandmarkDetector curr_landmark_detector;
+    // Used for the current frame
+    std::vector<int> window_sizes_current;
 
-	// How often should face detection be used to attempt reinitialisation, every n frames (set to negative not to reinit)
-	int reinit_video_every;
+    // How big is the tracking template that helps with large motions
+    float face_template_scale;
+    bool use_face_template;
 
-	// Determining which face detector to use for (re)initialisation, HAAR is quicker but provides more false positives and is not goot for in-the-wild conditions
-	// Also HAAR detector can detect smaller faces while HOG SVM is only capable of detecting faces at least 70px across
-	// MTCNN detector is much more accurate that the other two, and is even suitable for profile faces, but it is somewhat slower
-	enum FaceDetector{HAAR_DETECTOR, HOG_SVM_DETECTOR, MTCNN_DETECTOR};
+    // Where to load the model from
+    std::string model_location;
 
-	string haar_face_detector_location;
-	string mtcnn_face_detector_location;
-	FaceDetector curr_face_detector;
+    // this is used for the smooting of response maps (KDE sigma)
+    float sigma;
 
-	// Should the model be refined hierarchically (if available)
-	bool refine_hierarchical;
+    float reg_factor;    // weight put to regularisation
+    float weight_factor; // factor for weighted least squares
 
-	// Should the parameters be refined for different scales
-	bool refine_parameters;
+    // should multiple views be considered during reinit
+    bool multi_view;
 
-	FaceModelParameters();
+    // Based on model location, this affects the parameter settings
+    enum LandmarkDetector { CLM_DETECTOR, CLNF_DETECTOR, CECLM_DETECTOR };
+    LandmarkDetector curr_landmark_detector;
 
-	FaceModelParameters(vector<string> &arguments);
+    // How often should face detection be used to attempt reinitialisation,
+    // every n frames (set to negative not to reinit)
+    int reinit_video_every;
 
-	private:
-		void init();
-		void check_model_path(const std::string& root = "/");
+    // Determining which face detector to use for (re)initialisation, HAAR is
+    // quicker but provides more false positives and is not goot for in-the-wild
+    // conditions Also HAAR detector can detect smaller faces while HOG SVM is
+    // only capable of detecting faces at least 70px across MTCNN detector is
+    // much more accurate that the other two, and is even suitable for profile
+    // faces, but it is somewhat slower
+    enum FaceDetector { HAAR_DETECTOR, HOG_SVM_DETECTOR, MTCNN_DETECTOR };
 
-};
+    std::string haar_face_detector_location;
+    std::string mtcnn_face_detector_location;
+    FaceDetector curr_face_detector;
 
-}
+    // Should the model be refined hierarchically (if available)
+    bool refine_hierarchical;
 
-#endif // LANDMARK_DETECTOR_PARAM_H
+    // Should the parameters be refined for different scales
+    bool refine_parameters;
+
+    FaceModelParameters();
+
+    FaceModelParameters(std::vector<std::string>& arguments);
+
+  private:
+    void init();
+    void check_model_path(std::string model_path);
+    void check_model_paths();
+  };
+
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorUtils.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/LandmarkDetectorUtils.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,26 +15,28 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef LANDMARK_DETECTOR_UTILS_H
-#define LANDMARK_DETECTOR_UTILS_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
@@ -42,67 +45,122 @@
 
 #include "FaceDetectorMTCNN.h"
 
-using namespace std;
+namespace LandmarkDetector {
+  //===========================================================================
+  // Defining a set of useful utility functions to be used within CLNF
 
-namespace LandmarkDetector
-{
-	//===========================================================================	
-	// Defining a set of useful utility functions to be used within CLNF
+  //===========================================================================
+  // Fast patch expert response computation (linear model across a ROI) using
+  // normalised cross-correlation
+  //===========================================================================
+  // This is a modified version of openCV code that allows for precomputed dfts
+  // of templates and for precomputed dfts of an image _img is the input img,
+  // _img_dft it's dft (optional), _integral_img the images integral image
+  // (optional), squared integral image (optional), templ is the template we are
+  // convolving with, templ_dfts it's dfts at varying windows sizes (optional),
+  // _result - the output, method the type of convolution
+  void matchTemplate_m(const cv::Mat_<float>& input_img,
+                       cv::Mat_<double>& img_dft,
+                       cv::Mat& _integral_img,
+                       cv::Mat& _integral_img_sq,
+                       const cv::Mat_<float>& templ,
+                       std::map<int, cv::Mat_<double>>& templ_dfts,
+                       cv::Mat_<float>& result,
+                       int method);
 
-	//===========================================================================
-	// Fast patch expert response computation (linear model across a ROI) using normalised cross-correlation
-	//===========================================================================
-	// This is a modified version of openCV code that allows for precomputed dfts of templates and for precomputed dfts of an image
-	// _img is the input img, _img_dft it's dft (optional), _integral_img the images integral image (optional), squared integral image (optional), 
-	// templ is the template we are convolving with, templ_dfts it's dfts at varying windows sizes (optional),  _result - the output, method the type of convolution
-	void matchTemplate_m(const cv::Mat_<float>& input_img, cv::Mat_<double>& img_dft, cv::Mat& _integral_img, cv::Mat& _integral_img_sq, const cv::Mat_<float>&  templ, map<int, cv::Mat_<double> >& templ_dfts, cv::Mat_<float>& result, int method);
+  // Useful utility for grabing a bounding box around a set of 2D landmarks (as
+  // a 1D 2n x 1 vector of xs followed by doubles or as an n x 2 std::vector)
+  void ExtractBoundingBox(const cv::Mat_<float>& landmarks,
+                          float& min_x,
+                          float& max_x,
+                          float& min_y,
+                          float& max_y);
 
-	// Useful utility for grabing a bounding box around a set of 2D landmarks (as a 1D 2n x 1 vector of xs followed by doubles or as an n x 2 vector)
-	void ExtractBoundingBox(const cv::Mat_<float>& landmarks, float &min_x, float &max_x, float &min_y, float &max_y);
+  std::vector<cv::Point2f>
+  CalculateVisibleLandmarks(const cv::Mat_<float>& shape2D,
+                            const cv::Mat_<int>& visibilities);
+  std::vector<cv::Point2f> CalculateVisibleLandmarks(const CLNF& clnf_model);
+  std::vector<cv::Point2f> CalculateVisibleEyeLandmarks(const CLNF& clnf_model);
 
-	vector<cv::Point2f> CalculateVisibleLandmarks(const cv::Mat_<float>& shape2D, const cv::Mat_<int>& visibilities);
-	vector<cv::Point2f> CalculateVisibleLandmarks(const CLNF& clnf_model);
-	vector<cv::Point2f> CalculateVisibleEyeLandmarks(const CLNF& clnf_model);
+  std::vector<cv::Point2f> CalculateAllLandmarks(const cv::Mat_<float>& shape2D);
+  std::vector<cv::Point2f> CalculateAllLandmarks(const CLNF& clnf_model);
+  std::vector<cv::Point2f> CalculateAllEyeLandmarks(const CLNF& clnf_model);
+  std::vector<cv::Point3f> Calculate3DEyeLandmarks(
+      const CLNF& clnf_model, float fx, float fy, float cx, float cy);
 
-	vector<cv::Point2f> CalculateAllLandmarks(const cv::Mat_<float>& shape2D);
-	vector<cv::Point2f> CalculateAllLandmarks(const CLNF& clnf_model);
-	vector<cv::Point2f> CalculateAllEyeLandmarks(const CLNF& clnf_model);
-	vector<cv::Point3f> Calculate3DEyeLandmarks(const CLNF& clnf_model, float fx, float fy, float cx, float cy);
+  //============================================================================
+  // Face detection helpers
+  //============================================================================
 
-	//============================================================================
-	// Face detection helpers
-	//============================================================================
+  // Face detection using Haar cascade classifier
+  bool DetectFaces(std::vector<cv::Rect_<float>>& o_regions,
+                   const cv::Mat_<uchar>& intensity,
+                   float min_width = -1,
+                   cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
+  bool DetectFaces(std::vector<cv::Rect_<float>>& o_regions,
+                   const cv::Mat_<uchar>& intensity,
+                   cv::CascadeClassifier& classifier,
+                   float min_width = -1,
+                   cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
+  // The preference point allows for disambiguation if multiple faces are
+  // present (pick the closest one), if it is not set the biggest face is chosen
+  bool
+  DetectSingleFace(cv::Rect_<float>& o_region,
+                   const cv::Mat_<uchar>& intensity,
+                   cv::CascadeClassifier& classifier,
+                   const cv::Point preference = cv::Point(-1, -1),
+                   float min_width = -1,
+                   cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
 
-	// Face detection using Haar cascade classifier
-	bool DetectFaces(vector<cv::Rect_<float> >& o_regions, const cv::Mat_<uchar>& intensity, float min_width = -1, cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
-	bool DetectFaces(vector<cv::Rect_<float> >& o_regions, const cv::Mat_<uchar>& intensity, cv::CascadeClassifier& classifier, float min_width = -1, cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
-	// The preference point allows for disambiguation if multiple faces are present (pick the closest one), if it is not set the biggest face is chosen
-	bool DetectSingleFace(cv::Rect_<float>& o_region, const cv::Mat_<uchar>& intensity, cv::CascadeClassifier& classifier, const cv::Point preference = cv::Point(-1, -1), float min_width = -1, cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
+  // Face detection using HOG-SVM classifier
+  bool
+  DetectFacesHOG(std::vector<cv::Rect_<float>>& o_regions,
+                 const cv::Mat_<uchar>& intensity,
+                 std::vector<float>& confidences,
+                 float min_width = -1,
+                 cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
+  bool
+  DetectFacesHOG(std::vector<cv::Rect_<float>>& o_regions,
+                 const cv::Mat_<uchar>& intensity,
+                 dlib::frontal_face_detector& classifier,
+                 std::vector<float>& confidences,
+                 float min_width = -1,
+                 cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
+  // The preference point allows for disambiguation if multiple faces are
+  // present (pick the closest one), if it is not set the biggest face is chosen
+  bool DetectSingleFaceHOG(
+      cv::Rect_<float>& o_region,
+      const cv::Mat_<uchar>& intensity,
+      dlib::frontal_face_detector& classifier,
+      float& confidence,
+      const cv::Point preference = cv::Point(-1, -1),
+      float min_width = -1,
+      cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
 
-	// Face detection using HOG-SVM classifier
-	bool DetectFacesHOG(vector<cv::Rect_<float> >& o_regions, const cv::Mat_<uchar>& intensity, std::vector<float>& confidences, float min_width = -1, cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
-	bool DetectFacesHOG(vector<cv::Rect_<float> >& o_regions, const cv::Mat_<uchar>& intensity, dlib::frontal_face_detector& classifier, std::vector<float>& confidences, float min_width = -1, cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
-	// The preference point allows for disambiguation if multiple faces are present (pick the closest one), if it is not set the biggest face is chosen
-	bool DetectSingleFaceHOG(cv::Rect_<float>& o_region, const cv::Mat_<uchar>& intensity, dlib::frontal_face_detector& classifier, float& confidence, const cv::Point preference = cv::Point(-1, -1), float min_width = -1, cv::Rect_<float> roi = cv::Rect_<float>(0.0, 0.0, 1.0, 1.0));
+  // Face detection using Multi-task Convolutional Neural Network
+  bool DetectFacesMTCNN(std::vector<cv::Rect_<float>>& o_regions,
+                        const cv::Mat& image,
+                        LandmarkDetector::FaceDetectorMTCNN& detector,
+                        std::vector<float>& confidences);
+  // The preference point allows for disambiguation if multiple faces are
+  // present (pick the closest one), if it is not set the biggest face is chosen
+  bool DetectSingleFaceMTCNN(cv::Rect_<float>& o_region,
+                             const cv::Mat& image,
+                             LandmarkDetector::FaceDetectorMTCNN& detector,
+                             float& confidence,
+                             const cv::Point preference = cv::Point(-1, -1));
 
-	// Face detection using Multi-task Convolutional Neural Network
-	bool DetectFacesMTCNN(vector<cv::Rect_<float> >& o_regions, const cv::Mat& image, LandmarkDetector::FaceDetectorMTCNN& detector, std::vector<float>& confidences);
-	// The preference point allows for disambiguation if multiple faces are present (pick the closest one), if it is not set the biggest face is chosen
-	bool DetectSingleFaceMTCNN(cv::Rect_<float>& o_region, const cv::Mat& image, LandmarkDetector::FaceDetectorMTCNN& detector, float& confidence, const cv::Point preference = cv::Point(-1, -1));
+  //============================================================================
+  // Matrix reading functionality
+  //============================================================================
 
-	//============================================================================
-	// Matrix reading functionality
-	//============================================================================
+  // Reading a matrix written in a binary format
+  void ReadMatBin(std::ifstream& stream, cv::Mat& output_mat);
 
-	// Reading a matrix written in a binary format
-	void ReadMatBin(std::ifstream& stream, cv::Mat &output_mat);
+  // Reading in a matrix from a stream
+  void ReadMat(std::ifstream& stream, cv::Mat& output_matrix);
 
-	// Reading in a matrix from a stream
-	void ReadMat(std::ifstream& stream, cv::Mat& output_matrix);
+  // Skipping comments (lines starting with # symbol)
+  void SkipComments(std::ifstream& stream);
 
-	// Skipping comments (lines starting with # symbol)
-	void SkipComments(std::ifstream& stream);
-
-
-}
-#endif // LANDMARK_DETECTOR_UTILS_H
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/PDM.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/PDM.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,92 +15,119 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef PDM_H
-#define PDM_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 
 #include "LandmarkDetectorParameters.h"
 
-namespace LandmarkDetector
-{
-//===========================================================================
-// A linear 3D Point Distribution Model (constructed using Non-Rigid structure from motion or PCA)
-// Only describes the model but does not contain an instance of it (no local or global parameters are stored here)
-// Contains the utility functions to help manipulate the model
+namespace LandmarkDetector {
+  //===========================================================================
+  // A linear 3D Point Distribution Model (constructed using Non-Rigid structure
+  // from motion or PCA) Only describes the model but does not contain an
+  // instance of it (no local or global parameters are stored here) Contains the
+  // utility functions to help manipulate the model
 
-class PDM{
-	public:    
-    
-		// The 3D mean shape vector of the PDM [x1,..,xn,y1,...yn,z1,...,zn]
-		cv::Mat_<float> mean_shape;	
-  
-		// Principal components or variation bases of the model, 
-		cv::Mat_<float> princ_comp;
+  class PDM {
+  public:
+    // The 3D mean shape  of the PDM [x1,..,xn,y1,...yn,z1,...,zn]
+    cv::Mat_<float> mean_shape;
 
-		// Eigenvalues (variances) corresponding to the bases
-		cv::Mat_<float> eigen_values;
+    // Principal components or variation bases of the model,
+    cv::Mat_<float> princ_comp;
 
-		PDM(){;}
-		
-		// A copy constructor
-		PDM(const PDM& other);
-			
-		bool Read(string location);
+    // Eigenvalues (variances) corresponding to the bases
+    cv::Mat_<float> eigen_values;
 
-		// Number of vertices
-		inline int NumberOfPoints() const {return mean_shape.rows/3;}
-		
-		// Listing the number of modes of variation
-		inline int NumberOfModes() const {return princ_comp.cols;}
+    PDM() { ; }
 
-		void Clamp(cv::Mat_<float>& params_local, cv::Vec6f& params_global, const FaceModelParameters& params);
+    // A copy constructor
+    PDM(const PDM& other);
 
-		// Compute shape in object space (3D)
-		void CalcShape3D(cv::Mat_<float>& out_shape, const cv::Mat_<float>& params_local) const;
+    bool Read(std::string location);
 
-		// Compute shape in image space (2D)
-		void CalcShape2D(cv::Mat_<float>& out_shape, const cv::Mat_<float>& params_local, const cv::Vec6f& params_global) const;
-    
-		// provided the bounding box of a face and the local parameters (with optional rotation), generates the global parameters that can generate the face with the provided bounding box
-		void CalcParams(cv::Vec6f& out_params_global, const cv::Rect_<float>& bounding_box, const cv::Mat_<float>& params_local, const cv::Vec3f rotation = cv::Vec3f(0.0f));
+    // Number of vertices
+    inline int NumberOfPoints() const { return mean_shape.rows / 3; }
 
-		// Provided the landmark location compute global and local parameters best fitting it (can provide optional rotation for potentially better results)
-		void CalcParams(cv::Vec6f& out_params_global, cv::Mat_<float>& out_params_local, const cv::Mat_<float>& landmark_locations, const cv::Vec3f rotation = cv::Vec3f(0.0f));
+    // Listing the number of modes of variation
+    inline int NumberOfModes() const { return princ_comp.cols; }
 
-		// provided the model parameters, compute the bounding box of a face
-		void CalcBoundingBox(cv::Rect_<float>& out_bounding_box, const cv::Vec6f& params_global, const cv::Mat_<float>& params_local);
+    void Clamp(cv::Mat_<float>& params_local,
+               cv::Vec6f& params_global,
+               const FaceModelParameters& params);
 
-		// Helpers for computing Jacobians, and Jacobians with the weight matrix
-		void ComputeRigidJacobian(const cv::Mat_<float>& params_local, const cv::Vec6f& params_global, cv::Mat_<float> &Jacob, const cv::Mat_<float> W, cv::Mat_<float> &Jacob_t_w);
-		void ComputeJacobian(const cv::Mat_<float>& params_local, const cv::Vec6f& params_global, cv::Mat_<float> &Jacobian, const cv::Mat_<float> W, cv::Mat_<float> &Jacob_t_w);
+    // Compute shape in object space (3D)
+    void CalcShape3D(cv::Mat_<float>& out_shape,
+                     const cv::Mat_<float>& params_local) const;
 
-		// Given the current parameters, and the computed delta_p compute the updated parameters
-		void UpdateModelParameters(const cv::Mat_<float>& delta_p, cv::Mat_<float>& params_local, cv::Vec6f& params_global);
+    // Compute shape in image space (2D)
+    void CalcShape2D(cv::Mat_<float>& out_shape,
+                     const cv::Mat_<float>& params_local,
+                     const cv::Vec6f& params_global) const;
 
-	private:
-		// Helper utilities
-		static void Orthonormalise(cv::Matx33f &R);
+    // provided the bounding box of a face and the local parameters (with
+    // optional rotation), generates the global parameters that can generate the
+    // face with the provided bounding box
+    void CalcParams(cv::Vec6f& out_params_global,
+                    const cv::Rect_<float>& bounding_box,
+                    const cv::Mat_<float>& params_local,
+                    const cv::Vec3f rotation = cv::Vec3f(0.0f));
+
+    // Provided the landmark location compute global and local parameters best
+    // fitting it (can provide optional rotation for potentially better results)
+    void CalcParams(cv::Vec6f& out_params_global,
+                    cv::Mat_<float>& out_params_local,
+                    const cv::Mat_<float>& landmark_locations,
+                    const cv::Vec3f rotation = cv::Vec3f(0.0f));
+
+    // provided the model parameters, compute the bounding box of a face
+    void CalcBoundingBox(cv::Rect_<float>& out_bounding_box,
+                         const cv::Vec6f& params_global,
+                         const cv::Mat_<float>& params_local);
+
+    // Helpers for computing Jacobians, and Jacobians with the weight matrix
+    void ComputeRigidJacobian(const cv::Mat_<float>& params_local,
+                              const cv::Vec6f& params_global,
+                              cv::Mat_<float>& Jacob,
+                              const cv::Mat_<float> W,
+                              cv::Mat_<float>& Jacob_t_w);
+    void ComputeJacobian(const cv::Mat_<float>& params_local,
+                         const cv::Vec6f& params_global,
+                         cv::Mat_<float>& Jacobian,
+                         const cv::Mat_<float> W,
+                         cv::Mat_<float>& Jacob_t_w);
+
+    // Given the current parameters, and the computed delta_p compute the
+    // updated parameters
+    void UpdateModelParameters(const cv::Mat_<float>& delta_p,
+                               cv::Mat_<float>& params_local,
+                               cv::Vec6f& params_global);
+
+  private:
+    // Helper utilities
+    static void Orthonormalise(cv::Matx33f& R);
   };
   //===========================================================================
-}
-#endif // PDM_H
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/include/Patch_experts.h
+++ b/external/OpenFace/lib/local/LandmarkDetector/include/Patch_experts.h
@@ -4,8 +4,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -14,111 +15,149 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef PATCH_EXPERTS_H
-#define PATCH_EXPERTS_H
+#pragma once
 
 // OpenCV includes
 #include <opencv2/core/core.hpp>
 
-
-#include "SVR_patch_expert.h"
 #include "CCNF_patch_expert.h"
 #include "CEN_patch_expert.h"
 #include "PDM.h"
+#include "SVR_patch_expert.h"
 
-namespace LandmarkDetector
-{
-//===========================================================================
-/** 
-    Combined class for all of the patch experts
-*/
-class Patch_experts
-{
+namespace LandmarkDetector {
+  //===========================================================================
+  /**
+      Combined class for all of the patch experts
+  */
+  class Patch_experts {
 
-public:
+  public:
+    // The collection of SVR patch experts (for intensity/grayscale images), the
+    // experts are laid out scale->view->landmark
+    std::vector<std::vector<std::vector<Multi_SVR_patch_expert>>>
+        svr_expert_intensity;
 
-	// The collection of SVR patch experts (for intensity/grayscale images), the experts are laid out scale->view->landmark
-	vector<vector<vector<Multi_SVR_patch_expert> > >	svr_expert_intensity;
-	 
-	// The collection of LNF (CCNF) patch experts (for intensity images), the experts are laid out scale->view->landmark
-	vector<vector<vector<CCNF_patch_expert> > >			ccnf_expert_intensity;
+    // The collection of LNF (CCNF) patch experts (for intensity images), the
+    // experts are laid out scale->view->landmark
+    std::vector<std::vector<std::vector<CCNF_patch_expert>>>
+        ccnf_expert_intensity;
 
-	// The node connectivity for CCNF experts, at different window sizes and corresponding to separate edge features
-	vector<vector<cv::Mat_<float> > >					sigma_components;
+    // The node connectivity for CCNF experts, at different window sizes and
+    // corresponding to separate edge features
+    std::vector<std::vector<cv::Mat_<float>>> sigma_components;
 
-	// The collection of CEN patch experts (for intensity images), the experts are laid out scale->view->landmark
-	vector<vector<vector<CEN_patch_expert> > >			cen_expert_intensity;
+    // The collection of CEN patch experts (for intensity images), the experts
+    // are laid out scale->view->landmark
+    std::vector<std::vector<std::vector<CEN_patch_expert>>>
+        cen_expert_intensity;
 
-	//Useful to pre-allocate data for im2col so that it is not allocated for every iteration and every patch
-	vector< map<int, cv::Mat_<float> > > preallocated_im2col;
+    // Useful to pre-allocate data for im2col so that it is not allocated for
+    // every iteration and every patch
+    std::vector<std::map<int, cv::Mat_<float>>> preallocated_im2col;
 
-	// The available scales for intensity patch experts
-	vector<double>							patch_scaling;
+    // The available scales for intensity patch experts
+    std::vector<double> patch_scaling;
 
-	// The available views for the patch experts at every scale (in radians)
-	vector<vector<cv::Vec3d> >               centers;
+    // The available views for the patch experts at every scale (in radians)
+    std::vector<std::vector<cv::Vec3d>> centers;
 
-	// Landmark visibilities for each scale and view
-    vector<vector<cv::Mat_<int> > >          visibilities;
+    // Landmark visibilities for each scale and view
+    std::vector<std::vector<cv::Mat_<int>>> visibilities;
 
-	cv::Mat_<int>							mirror_inds;
-	cv::Mat_<int>							mirror_views;
+    cv::Mat_<int> mirror_inds;
+    cv::Mat_<int> mirror_views;
 
-	// Early termination calibration values, useful for CE-CLM model to speed up the multi-hypothesis setup
-	vector<double> early_term_weights;
-	vector<double> early_term_biases;
-	vector<double> early_term_cutoffs;
+    // Early termination calibration values, useful for CE-CLM model to speed up
+    // the multi-hypothesis setup
+    std::vector<double> early_term_weights;
+    std::vector<double> early_term_biases;
+    std::vector<double> early_term_cutoffs;
 
+    // A default constructor
+    Patch_experts() { ; }
 
-	// A default constructor
-	Patch_experts(){;}
+    // A copy constructor
+    Patch_experts(const Patch_experts& other);
 
-	// A copy constructor
-	Patch_experts(const Patch_experts& other);
+    // Returns the patch expert responses given a grayscale image.
+    // Additionally returns the transform from the image coordinates to the
+    // response coordinates (and vice versa). The computation also requires the
+    // current landmark locations to compute response around, the PDM
+    // corresponding to the desired model, and the parameters describing its
+    // instance Also need to provide the size of the area of interest and the
+    // desired scale of analysis
+    void Response(std::vector<cv::Mat_<float>>& patch_expert_responses,
+                  cv::Matx22f& sim_ref_to_img,
+                  cv::Matx22f& sim_img_to_ref,
+                  const cv::Mat_<float>& grayscale_image,
+                  const PDM& pdm,
+                  const cv::Vec6f& params_global,
+                  const cv::Mat_<float>& params_local,
+                  int window_size,
+                  int scale);
 
-	// Returns the patch expert responses given a grayscale image.
-	// Additionally returns the transform from the image coordinates to the response coordinates (and vice versa).
-	// The computation also requires the current landmark locations to compute response around, the PDM corresponding to the desired model, and the parameters describing its instance
-	// Also need to provide the size of the area of interest and the desired scale of analysis
-	void Response(vector<cv::Mat_<float> >& patch_expert_responses, cv::Matx22f& sim_ref_to_img, cv::Matx22f& sim_img_to_ref, const cv::Mat_<float>& grayscale_image, 
-							 const PDM& pdm, const cv::Vec6f& params_global, const cv::Mat_<float>& params_local, int window_size, int scale);
+    // Getting the best view associated with the current orientation
+    int GetViewIdx(const cv::Vec6f& params_global, int scale) const;
 
-	// Getting the best view associated with the current orientation
-	int GetViewIdx(const cv::Vec6f& params_global, int scale) const;
+    // The number of views at a particular scale
+    inline int nViews(size_t scale = 0) const {
+      return (int)centers[scale].size();
+    };
 
-	// The number of views at a particular scale
-	inline int nViews(size_t scale = 0) const { return (int)centers[scale].size(); };
+    // Reading in all of the patch experts
+    bool Read(std::vector<std::string> intensity_svr_expert_locations,
+              std::vector<std::string> intensity_ccnf_expert_locations,
+              std::vector<std::string> intensity_cen_expert_locations,
+              std::string early_term_loc = "");
 
-	// Reading in all of the patch experts
-	bool Read(vector<string> intensity_svr_expert_locations, vector<string> intensity_ccnf_expert_locations, vector<string> intensity_cen_expert_locations, string early_term_loc = "");
-   
+  private:
+    bool Read_SVR_patch_experts(
+        std::string expert_location,
+        std::vector<cv::Vec3d>& centers,
+        std::vector<cv::Mat_<int>>& visibility,
+        std::vector<std::vector<Multi_SVR_patch_expert>>& patches,
+        double& scale);
+    bool Read_CCNF_patch_experts(
+        std::string patchesFileLocation,
+        std::vector<cv::Vec3d>& centers,
+        std::vector<cv::Mat_<int>>& visibility,
+        std::vector<std::vector<CCNF_patch_expert>>& patches,
+        double& patchScaling);
+    bool
+    Read_CEN_patch_experts(std::string expert_location,
+                           std::vector<cv::Vec3d>& centers,
+                           std::vector<cv::Mat_<int>>& visibility,
+                           std::vector<std::vector<CEN_patch_expert>>& patches,
+                           double& scale);
 
-private:
-	bool Read_SVR_patch_experts(string expert_location, std::vector<cv::Vec3d>& centers, std::vector<cv::Mat_<int> >& visibility, std::vector<std::vector<Multi_SVR_patch_expert> >& patches, double& scale);
-	bool Read_CCNF_patch_experts(string patchesFileLocation, std::vector<cv::Vec3d>& centers, std::vector<cv::Mat_<int> >& visibility, std::vector<std::vector<CCNF_patch_expert> >& patches, double& patchScaling);
-	bool Read_CEN_patch_experts(string expert_location, std::vector<cv::Vec3d>& centers, std::vector<cv::Mat_<int> >& visibility, std::vector<std::vector<CEN_patch_expert> >& patches, double& scale);
+    // Helper for collecting visibilities
+    std::vector<int> Collect_visible_landmarks(
+        std::vector<std::vector<cv::Mat_<int>>> visibilities,
+        int scale,
+        int view_id,
+        int n);
+  };
 
-	// Helper for collecting visibilities
-	std::vector<int> Collect_visible_landmarks(vector<vector<cv::Mat_<int> > > visibilities, int scale, int view_id, int n);
-};
- 
-}
-#endif // PATCH_EXPERTS_H
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/LandmarkDetector/src/LandmarkDetectorParameters.cpp
+++ b/external/OpenFace/lib/local/LandmarkDetector/src/LandmarkDetectorParameters.cpp
@@ -49,274 +49,208 @@
 #include <iostream>
 #include <sstream>
 
-#ifndef CONFIG_DIR
-#define CONFIG_DIR "~"
-#endif
-
 using namespace std;
 using boost::filesystem::exists;
 using boost::filesystem::path;
 
-using namespace LandmarkDetector;
+namespace LandmarkDetector {
 
-FaceModelParameters::FaceModelParameters() {
-  // initialise the default values
-  init();
-  check_model_path();
-}
-
-FaceModelParameters::FaceModelParameters(vector<string> &arguments) {
-  // initialise the default values
-  init();
-
-  // First element is reserved for the executable location (useful for finding
-  // relative model locs)
-  path root = path(arguments[0]).parent_path();
-
-  bool *valid = new bool[arguments.size()];
-  valid[0] = true;
-
-  for (size_t i = 1; i < arguments.size(); ++i) {
-    valid[i] = true;
-
-    if (arguments[i].compare("-mloc") == 0) {
-      string model_loc = arguments[i + 1];
-      model_location = model_loc;
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    if (arguments[i].compare("-fdloc") == 0) {
-      string face_detector_loc = arguments[i + 1];
-      haar_face_detector_location = face_detector_loc;
-      curr_face_detector = HAAR_DETECTOR;
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    if (arguments[i].compare("-sigma") == 0) {
-      stringstream data(arguments[i + 1]);
-      data >> sigma;
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    else if (arguments[i].compare("-w_reg") == 0) {
-      stringstream data(arguments[i + 1]);
-      data >> weight_factor;
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    else if (arguments[i].compare("-reg") == 0) {
-      stringstream data(arguments[i + 1]);
-      data >> reg_factor;
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    else if (arguments[i].compare("-multi_view") == 0) {
-
-      stringstream data(arguments[i + 1]);
-      int m_view;
-      data >> m_view;
-
-      multi_view = (bool)(m_view != 0);
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    else if (arguments[i].compare("-validate_detections") == 0) {
-      stringstream data(arguments[i + 1]);
-      int v_det;
-      data >> v_det;
-
-      validate_detections = (bool)(v_det != 0);
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    else if (arguments[i].compare("-n_iter") == 0) {
-      stringstream data(arguments[i + 1]);
-      data >> num_optimisation_iteration;
-
-      valid[i] = false;
-      valid[i + 1] = false;
-      i++;
-    }
-    else if (arguments[i].compare("-wild") == 0) {
-      // For in the wild fitting these parameters are suitable
-      window_sizes_init = vector<int>(4);
-      window_sizes_init[0] = 15;
-      window_sizes_init[1] = 13;
-      window_sizes_init[2] = 11;
-      window_sizes_init[3] = 11;
-
-      sigma = 1.25;
-      reg_factor = 35;
-      weight_factor = 2.5;
-      num_optimisation_iteration = 10;
-
-      valid[i] = false;
-
-      // For in-the-wild images use an in-the wild detector
-      curr_face_detector = MTCNN_DETECTOR;
-
-      // Use multi-view hypotheses if in-the-wild setting
-      multi_view = true;
+  void FaceModelParameters::check_model_path(string model_path) {
+    if (!exists(path(model_path))) {
+      throw runtime_error("Could not find the the model " + model_path);
     }
   }
 
-  for (int i = (int)arguments.size() - 1; i >= 0; --i) {
-    if (!valid[i]) {
-      arguments.erase(arguments.begin() + i);
+  void FaceModelParameters::check_model_paths() {
+    this->check_model_path(this->model_location);
+    this->check_model_path(this->haar_face_detector_location);
+    this->check_model_path(this->mtcnn_face_detector_location);
+  }
+
+  FaceModelParameters::FaceModelParameters() {
+    // initialise the default values
+    this->init();
+    this->check_model_paths();
+  }
+
+  FaceModelParameters::FaceModelParameters(vector<string>& arguments) {
+    // initialise the default values
+    this->init();
+
+    // First element is reserved for the executable location (useful for finding
+    // relative model locs)
+    path root = path(arguments[0]).parent_path();
+
+    bool* valid = new bool[arguments.size()];
+    valid[0] = true;
+
+    for (size_t i = 1; i < arguments.size(); ++i) {
+      valid[i] = true;
+
+      if (arguments[i].compare("-mloc") == 0) {
+        string model_loc = arguments[i + 1];
+        this->model_location = model_loc;
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      if (arguments[i].compare("-fdloc") == 0) {
+        string face_detector_loc = arguments[i + 1];
+        this->haar_face_detector_location = face_detector_loc;
+        this->curr_face_detector = HAAR_DETECTOR;
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      if (arguments[i].compare("-sigma") == 0) {
+        stringstream data(arguments[i + 1]);
+        data >> sigma;
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      else if (arguments[i].compare("-w_reg") == 0) {
+        stringstream data(arguments[i + 1]);
+        data >> this->weight_factor;
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      else if (arguments[i].compare("-reg") == 0) {
+        stringstream data(arguments[i + 1]);
+        data >> this->reg_factor;
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      else if (arguments[i].compare("-multi_view") == 0) {
+
+        stringstream data(arguments[i + 1]);
+        int m_view;
+        data >> m_view;
+
+        this->multi_view = (bool)(m_view != 0);
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      else if (arguments[i].compare("-validate_detections") == 0) {
+        stringstream data(arguments[i + 1]);
+        int v_det;
+        data >> v_det;
+
+        this->validate_detections = (bool)(v_det != 0);
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      else if (arguments[i].compare("-n_iter") == 0) {
+        stringstream data(arguments[i + 1]);
+        data >> this->num_optimisation_iteration;
+
+        valid[i] = false;
+        valid[i + 1] = false;
+        i++;
+      }
+      else if (arguments[i].compare("-wild") == 0) {
+        // For in the wild fitting these parameters are suitable
+        this->window_sizes_init = vector<int>(4);
+        this->window_sizes_init[0] = 15;
+        this->window_sizes_init[1] = 13;
+        this->window_sizes_init[2] = 11;
+        this->window_sizes_init[3] = 11;
+
+        this->sigma = 1.25;
+        this->reg_factor = 35;
+        this->weight_factor = 2.5;
+        this->num_optimisation_iteration = 10;
+
+        valid[i] = false;
+
+        // For in-the-wild images use an in-the wild detector
+        this->curr_face_detector = MTCNN_DETECTOR;
+
+        // Use multi-view hypotheses if in-the-wild setting
+        this->multi_view = true;
+      }
+    }
+
+    for (int i = (int)arguments.size() - 1; i >= 0; --i) {
+      if (!valid[i]) {
+        arguments.erase(arguments.begin() + i);
+      }
+    }
+
+    this->check_model_paths();
+    path model_path = path(this->model_location);
+
+    if (model_path.stem().string().compare("main_ceclm_general") == 0) {
+      this->curr_landmark_detector = this->CECLM_DETECTOR;
+      this->sigma = 1.5f * sigma;
+      this->reg_factor = 0.9f * reg_factor;
+    }
+    else if (model_path.stem().string().compare("main_clnf_general") == 0) {
+      this->curr_landmark_detector = this->CLNF_DETECTOR;
+    }
+    else if (model_path.stem().string().compare("main_clm_general") == 0) {
+      this->curr_landmark_detector = this->CLM_DETECTOR;
     }
   }
 
-  // Make sure model_location is valid
-  // First check working directory, then the executable's directory, then the
-  // config path set by the build process.
-  path config_path = path(CONFIG_DIR);
-  path model_path = path(model_location);
-  if (exists(model_path)) {
-    model_location = model_path.string();
+  void FaceModelParameters::init() {
+
+    // number of iterations that will be performed at each scale
+    this->num_optimisation_iteration = 5;
+
+    // using an external face checker based on SVM
+    this->validate_detections = true;
+
+    // Using hierarchical refinement by default (can be turned off)
+    this->refine_hierarchical = true;
+
+    // Refining parameters by default
+    this->refine_parameters = true;
+
+    // For fast tracking
+    this->window_sizes_small = {0, 9, 7, 0};
+
+    // Just for initialisation
+    this->window_sizes_init = {11, 9, 7, 5};
+
+    this->face_template_scale = 0.3f;
+    // Off by default (as it might lead to some slight inaccuracies in slowly
+    // moving faces)
+    use_face_template = false;
+
+    // For first frame use the initialisation
+    this->window_sizes_current = window_sizes_init;
+
+    this->model_location = this->OpenFace_models_dir +
+                           "/landmark_detection/main_ceclm_general.txt";
+    this->curr_landmark_detector = CECLM_DETECTOR;
+
+    this->sigma = 1.5f;
+    this->reg_factor = 25.0f;
+    this->weight_factor = 0.0f; // By default do not use NU-RLMS for videos as
+                                // it does not work as well for them
+
+    this->validation_boundary = 0.725f;
+
+    this->limit_pose = true;
+    this->multi_view = false;
+
+    this->reinit_video_every = 2;
+
+    // Face detection
+    this->haar_face_detector_location =
+        this->OpenFace_models_dir +
+        "/classifiers/haarcascade_frontalface_alt.xml";
+    this->mtcnn_face_detector_location =
+        this->OpenFace_models_dir +
+        "/landmark_detection/mtcnn_detector/MTCNN_detector.txt";
+
+    // By default use MTCNN
+    this->curr_face_detector = MTCNN_DETECTOR;
   }
-  else if (exists(root / model_path)) {
-    model_location = (root / model_path).string();
-  }
-  else if (exists(config_path / model_path)) {
-    model_location = (config_path / model_path).string();
-  }
-  else {
-    cout << "Could not find the landmark detection model to load" << endl;
-  }
 
-  if (model_path.stem().string().compare("main_ceclm_general") == 0) {
-    curr_landmark_detector = CECLM_DETECTOR;
-    sigma = 1.5f * sigma;
-    reg_factor = 0.9f * reg_factor;
-  }
-  else if (model_path.stem().string().compare("main_clnf_general") == 0) {
-    curr_landmark_detector = CLNF_DETECTOR;
-  }
-  else if (model_path.stem().string().compare("main_clm_general") == 0) {
-    curr_landmark_detector = CLM_DETECTOR;
-  }
-
-  // Make sure face detector location is valid
-  // First check working directory, then the executable's directory, then the
-  // config path set by the build process.
-  model_path = path(haar_face_detector_location);
-  if (exists(model_path)) {
-    haar_face_detector_location = model_path.string();
-  }
-  else if (exists(root / model_path)) {
-    haar_face_detector_location = (root / model_path).string();
-  }
-  else if (exists(config_path / model_path)) {
-    haar_face_detector_location = (config_path / model_path).string();
-  }
-  else {
-    cout << "Could not find the HAAR face detector location" << endl;
-  }
-
-  // Make sure face detector location is valid
-  // First check working directory, then the executable's directory, then the
-  // config path set by the build process.
-  model_path = path(mtcnn_face_detector_location);
-  if (exists(model_path)) {
-    mtcnn_face_detector_location = model_path.string();
-  }
-  else if (exists(root / model_path)) {
-    mtcnn_face_detector_location = (root / model_path).string();
-  }
-  else if (exists(config_path / model_path)) {
-    mtcnn_face_detector_location = (config_path / model_path).string();
-  }
-  else {
-    cout << "Could not find the MTCNN face detector location" << endl;
-  }
-  check_model_path(root.string());
-}
-
-void FaceModelParameters::check_model_path(const std::string &root) {
-  // Make sure model_location is valid
-  // First check working directory, then the executable's directory, then the
-  // config path set by the build process.
-  path config_path = path(CONFIG_DIR);
-  path model_path = path(model_location);
-  path root_path = path(root);
-
-  if (exists(model_path)) {
-    model_location = model_path.string();
-  }
-  else if (exists(root_path / model_path)) {
-    model_location = (root_path / model_path).string();
-  }
-  else if (exists(config_path / model_path)) {
-    model_location = (config_path / model_path).string();
-  }
-  else {
-    cout << "Could not find the landmark detection model to load" << endl;
-  }
-}
-
-void FaceModelParameters::init() {
-
-  // number of iterations that will be performed at each scale
-  num_optimisation_iteration = 5;
-
-  // using an external face checker based on SVM
-  validate_detections = true;
-
-  // Using hierarchical refinement by default (can be turned off)
-  refine_hierarchical = true;
-
-  // Refining parameters by default
-  refine_parameters = true;
-
-  window_sizes_small = vector<int>(4);
-  window_sizes_init = vector<int>(4);
-
-  // For fast tracking
-  window_sizes_small[0] = 0;
-  window_sizes_small[1] = 9;
-  window_sizes_small[2] = 7;
-  window_sizes_small[3] = 0;
-
-  // Just for initialisation
-  window_sizes_init.at(0) = 11;
-  window_sizes_init.at(1) = 9;
-  window_sizes_init.at(2) = 7;
-  window_sizes_init.at(3) = 5;
-
-  face_template_scale = 0.3f;
-  // Off by default (as it might lead to some slight inaccuracies in slowly
-  // moving faces)
-  use_face_template = false;
-
-  // For first frame use the initialisation
-  window_sizes_current = window_sizes_init;
-
-  model_location = "models/landmark_detection/main_ceclm_general.txt";
-  curr_landmark_detector = CECLM_DETECTOR;
-
-  sigma = 1.5f;
-  reg_factor = 25.0f;
-  weight_factor = 0.0f; // By default do not use NU-RLMS for videos as it does
-                        // not work as well for them
-
-  validation_boundary = 0.725f;
-
-  limit_pose = true;
-  multi_view = false;
-
-  reinit_video_every = 2;
-
-  // Face detection
-  haar_face_detector_location = "models/classifiers/haarcascade_frontalface_alt.xml";
-  mtcnn_face_detector_location = "models/landmark_detection/mtcnn_detector/MTCNN_detector.txt";
-
-  // By default use MTCNN
-  curr_face_detector = MTCNN_DETECTOR;
-}
+} // namespace LandmarkDetector

--- a/external/OpenFace/lib/local/Utilities/include/VisualizationUtils.h
+++ b/external/OpenFace/lib/local/Utilities/include/VisualizationUtils.h
@@ -3,8 +3,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -13,62 +14,73 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef VISUALIZATION_UTILS_H
-#define VISUALIZATION_UTILS_H
+#pragma once
 
 #include <opencv2/core/core.hpp>
 
-#include <vector>
 #include <queue>
+#include <vector>
 
-namespace Utilities
-{
+namespace Utilities {
 
-	// Drawing a bounding box around the face in an image
-	void DrawBox(cv::Mat image, cv::Vec6f pose, cv::Scalar color, int thickness, float fx, float fy, float cx, float cy);
-	void DrawBox(const std::vector<std::pair<cv::Point2f, cv::Point2f>>& lines, cv::Mat image, cv::Scalar color, int thickness);
+  // Drawing a bounding box around the face in an image
+  void DrawBox(cv::Mat image,
+               cv::Vec6f pose,
+               cv::Scalar color,
+               int thickness,
+               float fx,
+               float fy,
+               float cx,
+               float cy);
+  void DrawBox(const std::vector<std::pair<cv::Point2f, cv::Point2f>>& lines,
+               cv::Mat image,
+               cv::Scalar color,
+               int thickness);
 
-	// Computing a bounding box to be drawn
-	std::vector<std::pair<cv::Point2f, cv::Point2f>> CalculateBox(cv::Vec6f pose, float fx, float fy, float cx, float cy);
+  // Computing a bounding box to be drawn
+  std::vector<std::pair<cv::Point2f, cv::Point2f>>
+  CalculateBox(cv::Vec6f pose, float fx, float fy, float cx, float cy);
 
-    void Visualise_FHOG(const cv::Mat_<double>& descriptor, int num_rows, int num_cols, cv::Mat& visualisation);
+  void Visualise_FHOG(const cv::Mat_<double>& descriptor,
+                      int num_rows,
+                      int num_cols,
+                      cv::Mat& visualisation);
 
-	class FpsTracker
-	{
-	public:
-		
-		double history_length;
+  class FpsTracker {
+  public:
+    double history_length;
 
-		void AddFrame();
+    void AddFrame();
 
-		double GetFPS();
+    double GetFPS();
 
-		FpsTracker();
+    FpsTracker();
 
-	private:
-		std::queue<double> frame_times;
+  private:
+    std::queue<double> frame_times;
 
-		void DiscardOldFrames();
+    void DiscardOldFrames();
+  };
 
-	};
-
-}
-#endif // VISUALIZATION_UTILS_H
+} // namespace Utilities

--- a/external/OpenFace/lib/local/Utilities/include/Visualizer.h
+++ b/external/OpenFace/lib/local/Utilities/include/Visualizer.h
@@ -3,8 +3,9 @@
 //
 // ACADEMIC OR NON-PROFIT ORGANIZATION NONCOMMERCIAL RESEARCH USE ONLY
 //
-// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS LICENSE AGREEMENT.  
-// IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR DOWNLOAD THE SOFTWARE.
+// BY USING OR DOWNLOADING THE SOFTWARE, YOU ARE AGREEING TO THE TERMS OF THIS
+// LICENSE AGREEMENT. IF YOU DO NOT AGREE WITH THESE TERMS, YOU MAY NOT USE OR
+// DOWNLOAD THE SOFTWARE.
 //
 // License can be found in OpenFace-license.txt
 //
@@ -13,26 +14,28 @@
 //       reports and manuals, must cite at least one of the following works:
 //
 //       OpenFace 2.0: Facial Behavior Analysis Toolkit
-//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe Morency
-//       in IEEE International Conference on Automatic Face and Gesture Recognition, 2018  
+//       Tadas Baltrušaitis, Amir Zadeh, Yao Chong Lim, and Louis-Philippe
+//       Morency in IEEE International Conference on Automatic Face and Gesture
+//       Recognition, 2018
 //
-//       Convolutional experts constrained local model for facial landmark detection.
-//       A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency,
-//       in Computer Vision and Pattern Recognition Workshops, 2017.    
+//       Convolutional experts constrained local model for facial landmark
+//       detection. A. Zadeh, T. Baltrušaitis, and Louis-Philippe Morency, in
+//       Computer Vision and Pattern Recognition Workshops, 2017.
 //
 //       Rendering of Eyes for Eye-Shape Registration and Gaze Estimation
-//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter Robinson, and Andreas Bulling 
-//       in IEEE International. Conference on Computer Vision (ICCV),  2015 
+//       Erroll Wood, Tadas Baltrušaitis, Xucong Zhang, Yusuke Sugano, Peter
+//       Robinson, and Andreas Bulling in IEEE International. Conference on
+//       Computer Vision (ICCV),  2015
 //
-//       Cross-dataset learning and person-specific normalisation for automatic Action Unit detection
-//       Tadas Baltrušaitis, Marwa Mahmoud, and Peter Robinson 
-//       in Facial Expression Recognition and Analysis Challenge, 
-//       IEEE International Conference on Automatic Face and Gesture Recognition, 2015 
+//       Cross-dataset learning and person-specific normalisation for automatic
+//       Action Unit detection Tadas Baltrušaitis, Marwa Mahmoud, and Peter
+//       Robinson in Facial Expression Recognition and Analysis Challenge, IEEE
+//       International Conference on Automatic Face and Gesture Recognition,
+//       2015
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef VISUALIZER_H
-#define VISUALIZER_H
+#pragma once
 
 // System includes
 #include <vector>
@@ -41,72 +44,81 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-namespace Utilities
-{
+namespace Utilities {
 
-	//===========================================================================
-	/**
-	A class for recording data processed by OpenFace (facial landmarks, head pose, facial action units, aligned face, HOG features, and tracked video
-	*/
-	class Visualizer {
+  //===========================================================================
+  /**
+  A class for recording data processed by OpenFace (facial landmarks, head pose,
+  facial action units, aligned face, HOG features, and tracked video
+  */
+  class Visualizer {
 
-	public:
+  public:
+    // The constructor for the visualizer that specifies what to visualize
+    Visualizer(std::vector<std::string> arguments);
+    Visualizer(bool vis_track, bool vis_hog, bool vis_align, bool vis_aus);
 
-		// The constructor for the visualizer that specifies what to visualize
-		Visualizer(std::vector<std::string> arguments);
-		Visualizer(bool vis_track, bool vis_hog, bool vis_align, bool vis_aus);
+    // Adding observations to the visualizer
 
-		// Adding observations to the visualizer
-		
-		// Pose related observations
-		void SetImage(const cv::Mat& canvas, float fx, float fy, float cx, float cy);
+    // Pose related observations
+    void
+    SetImage(const cv::Mat& canvas, float fx, float fy, float cx, float cy);
 
-		// All observations relevant to facial landmarks (optional visibilities parameter to not display all landmarks)
-		void SetObservationLandmarks(const cv::Mat_<float>& landmarks_2D, double confidence, const cv::Mat_<int>& visibilities = cv::Mat_<int>());
+    // All observations relevant to facial landmarks (optional visibilities
+    // parameter to not display all landmarks)
+    void SetObservationLandmarks(
+        const cv::Mat_<float>& landmarks_2D,
+        double confidence,
+        const cv::Mat_<int>& visibilities = cv::Mat_<int>());
 
-		// Pose related observations
-		void SetObservationPose(const cv::Vec6f& pose, double confidence);
-		
-		void SetObservationActionUnits(const std::vector<std::pair<std::string, double> >& au_intensities, const std::vector<std::pair<std::string, double> >& au_occurences);
+    // Pose related observations
+    void SetObservationPose(const cv::Vec6f& pose, double confidence);
 
-		// Gaze related observations
-		void SetObservationGaze(const cv::Point3f& gazeDirection0, const cv::Point3f& gazeDirection1, const std::vector<cv::Point2f>& eye_landmarks, const std::vector<cv::Point3f>& eye_landmarks3d, double confidence);
+    void SetObservationActionUnits(
+        const std::vector<std::pair<std::string, double>>& au_intensities,
+        const std::vector<std::pair<std::string, double>>& au_occurences);
 
-		// Face alignment related observations
-		void SetObservationFaceAlign(const cv::Mat& aligned_face);
+    // Gaze related observations
+    void SetObservationGaze(const cv::Point3f& gazeDirection0,
+                            const cv::Point3f& gazeDirection1,
+                            const std::vector<cv::Point2f>& eye_landmarks,
+                            const std::vector<cv::Point3f>& eye_landmarks3d,
+                            double confidence);
 
-		// HOG feature related observations
-		void SetObservationHOG(const cv::Mat_<double>& hog_descriptor, int num_cols, int num_rows);
+    // Face alignment related observations
+    void SetObservationFaceAlign(const cv::Mat& aligned_face);
 
-		void SetFps(double fps);
+    // HOG feature related observations
+    void SetObservationHOG(const cv::Mat_<double>& hog_descriptor,
+                           int num_cols,
+                           int num_rows);
 
-		// Return key-press that could have resulted in the open windows
-		char ShowObservation();
+    void SetFps(double fps);
 
-		cv::Mat GetVisImage();
-		cv::Mat GetHOGVis();
+    // Return key-press that could have resulted in the open windows
+    char ShowObservation();
 
-		// Keeping track of what we're visualizing
-		bool vis_track;
-		bool vis_hog;
-		bool vis_align;
-		bool vis_aus;
+    cv::Mat GetVisImage();
+    cv::Mat GetHOGVis();
 
-		// Can be adjusted to show less confident frames
-		double visualisation_boundary = 0.4;
+    // Keeping track of what we're visualizing
+    bool vis_track;
+    bool vis_hog;
+    bool vis_align;
+    bool vis_aus;
 
-	private:
+    // Can be adjusted to show less confident frames
+    double visualisation_boundary = 0.4;
 
-		// Temporary variables for visualization
-		cv::Mat captured_image; // out canvas
-		cv::Mat tracked_image;
-		cv::Mat hog_image;
-		cv::Mat aligned_face_image;
-		cv::Mat action_units_image;
+  private:
+    // Temporary variables for visualization
+    cv::Mat captured_image; // out canvas
+    cv::Mat tracked_image;
+    cv::Mat hog_image;
+    cv::Mat aligned_face_image;
+    cv::Mat action_units_image;
 
-		// Useful for drawing 3d
-		float fx, fy, cx, cy;
-
-	};
-}
-#endif
+    // Useful for drawing 3d
+    float fx, fy, cx, cy;
+  };
+} // namespace Utilities

--- a/src/WebcamSensor.h
+++ b/src/WebcamSensor.h
@@ -12,16 +12,16 @@ namespace tomcat {
   class WebcamSensor {
   public:
     WebcamSensor()
-        : visualizer(true, false, false, false), det_parameters(arguments) {}
+        : visualizer(true, false, false, false), det_parameters(this->arguments) {}
 
     void initialize() {
       // The modules that are being used for tracking
       this->face_model = LandmarkDetector::CLNF();
-      if (!face_model.loaded_successfully) {
+      if (!this->face_model.loaded_successfully) {
         fmt::print("ERROR: Could not load the landmark detector");
       }
 
-      if (!face_model.eye_model) {
+      if (!this->face_model.eye_model) {
         fmt::print("WARNING: no eye model found");
       }
 
@@ -35,7 +35,7 @@ namespace tomcat {
     void get_observation();
 
   private:
-    vector<string> arguments = {"-device", "0"};
+    std::vector<std::string> arguments = {"-device", "0"};
     Utilities::Visualizer visualizer;
     cv::Mat rgb_image;
     Utilities::SequenceCapture sequence_reader;


### PR DESCRIPTION
This PR:

* Fixes the loading of the face landmark detector parameters in OpenFace, to now use the `TOMCAT` environment variable
* Cleans up and refactors the OpenFace source code a bit.