### PR TITLE
Malmo code cleanup and script added to upload to vanga

### DIFF
--- a/external/malmo/Malmo/src/AgentHost.cpp
+++ b/external/malmo/Malmo/src/AgentHost.cpp
@@ -170,7 +170,7 @@ namespace malmo {
                                              "MALMO_KILL_CLIENT\n",
                                              false);
     }
-    catch (std::exception& e) {
+    catch (exception& e) {
       // This is expected quite often - client is likely not running.
       LOGINFO(LT("Exception attempting to kill client: "), e.what());
       return false;
@@ -197,21 +197,21 @@ namespace malmo {
                                const MissionRecordSpec& mission_record,
                                int role,
                                string unique_experiment_id) {
-    std::call_once(test_schemas_flag, testSchemasCompatible);
+    call_once(test_schemas_flag, testSchemasCompatible);
 
     LOGSIMPLE(LOG_FINE, "testSchemasCompatible\n");
     if (role < 0 || role >= mission.getNumberOfAgents()) {
       if (mission.getNumberOfAgents() == 1)
         throw MissionException(
-            "Role " + std::to_string(role) +
+            "Role " + to_string(role) +
                 " is invalid for this single-agent mission - must be 0.",
             MissionException::MISSION_BAD_ROLE_REQUEST);
       else
         throw MissionException(
-            "Role " + std::to_string(role) +
+            "Role " + to_string(role) +
                 " is invalid for this multi-agent mission - must be in range "
                 "0-" +
-                std::to_string(mission.getNumberOfAgents() - 1) + ".",
+                to_string(mission.getNumberOfAgents() - 1) + ".",
             MissionException::MISSION_BAD_ROLE_REQUEST);
     }
     if (mission.isVideoRequested(role)) {
@@ -257,8 +257,7 @@ namespace malmo {
               "There are not enough clients available in the ClientPool to "
               "start "
               "this " +
-                  std::to_string(mission.getNumberOfAgents()) +
-                  " agent mission.",
+                  to_string(mission.getNumberOfAgents()) + " agent mission.",
               MissionException::MISSION_INSUFFICIENT_CLIENTS_AVAILABLE);
       }
       pool = reservedAgents;
@@ -283,7 +282,7 @@ namespace malmo {
     //     time this->world_state->is_mission_running is false.
 
     if (this->current_mission_record->isRecording()) {
-      std::ofstream missionInitXML(
+      ofstream missionInitXML(
           this->current_mission_record->getMissionInitPath());
       missionInitXML << this->current_mission_init->getAsXML(true);
     }
@@ -408,7 +407,7 @@ namespace malmo {
                                                request,
                                                false);
       }
-      catch (std::exception& e) {
+      catch (exception& e) {
         // This is expected quite often - client is likely not running.
         LOGINFO(LT("Client could not be contacted: "),
                 item->ip_address,
@@ -447,7 +446,7 @@ namespace malmo {
                                                  "MALMO_CANCEL_REQUEST\n",
                                                  false);
         }
-        catch (std::exception&) {
+        catch (exception&) {
           // This is not expected, and probably means something bad has
           // happened.
           LOGERROR(LT("Failed to cancel reservation request with "),
@@ -485,7 +484,7 @@ namespace malmo {
                                                request,
                                                false);
       }
-      catch (std::exception&) {
+      catch (exception&) {
         // This is expected quite often - client is likely not running.
         continue;
       }
@@ -563,7 +562,7 @@ namespace malmo {
                                                mission_init_xml,
                                                false);
       }
-      catch (std::exception&) {
+      catch (exception&) {
         LOGINFO(LT("No response from "),
                 item->ip_address,
                 LT(":"),
@@ -782,7 +781,7 @@ namespace malmo {
     try {
       boost::property_tree::read_xml(ss, pt);
     }
-    catch (std::exception& e) {
+    catch (exception& e) {
       TimestampedString error_message(xml);
       error_message.text =
           string("Error parsing mission control message as XML: ") + e.what() +
@@ -818,7 +817,7 @@ namespace malmo {
 
         if (status != MissionEndedXML::ENDED &&
             status != MissionEndedXML::PLAYER_DIED) {
-          std::ostringstream oss;
+          ostringstream oss;
           oss << "Mission ended abnormally: "
               << mission_ended.getHumanReadableStatus();
           TimestampedString error_message(xml);
@@ -864,8 +863,8 @@ namespace malmo {
           xml.text = mission_ended.toXml();
         }
       }
-      catch (const std::exception& e) {
-        std::ostringstream oss;
+      catch (const exception& e) {
+        ostringstream oss;
         oss << "Error processing MissionEnded message XML: " << e.what()
             << " : " << xml.text.substr(0, 20) << "...";
         TimestampedString error_message(xml);
@@ -875,7 +874,7 @@ namespace malmo {
         return;
       }
       if (this->current_mission_record->isRecording()) {
-        std::ofstream missionEndedXML(
+        ofstream missionEndedXML(
             this->current_mission_record->getMissionEndedPath());
         missionEndedXML << xml.text;
       }
@@ -1018,8 +1017,8 @@ namespace malmo {
       reward.createFromSimpleString(message.timestamp, message.text);
       this->processReceivedReward(reward);
     }
-    catch (std::exception& e) {
-      std::ostringstream oss;
+    catch (exception& e) {
+      ostringstream oss;
       oss << "Error parsing Reward message: " << e.what() << " : "
           << message.text;
       TimestampedString error_message(message);
@@ -1093,7 +1092,7 @@ namespace malmo {
     try {
       this->commands_connection->send(full_command);
     }
-    catch (const std::runtime_error& e) {
+    catch (const runtime_error& e) {
       TimestampedString error_message(
           boost::posix_time::microsec_clock::universal_time(),
           "AgentHost::sendCommand : failed to send command: " +
@@ -1106,7 +1105,7 @@ namespace malmo {
     if (this->commands_stream.is_open()) {
       string timestamp = boost::posix_time::to_iso_string(
           boost::posix_time::microsec_clock::universal_time());
-      this->commands_stream << timestamp << " " << command << std::endl;
+      this->commands_stream << timestamp << " " << command << endl;
     }
   }
 
@@ -1118,7 +1117,7 @@ namespace malmo {
     return this->current_mission_init;
   }
 
-  std::ostream& operator<<(std::ostream& os, const AgentHost& agent_host) {
+  ostream& operator<<(ostream& os, const AgentHost& agent_host) {
     os << "AgentHost";
     if (agent_host.getMissionInit())
       os << ": active (with mission)";

--- a/external/malmo/Malmo/src/MissionRecord.cpp
+++ b/external/malmo/Malmo/src/MissionRecord.cpp
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
@@ -24,8 +27,8 @@
 // Boost:
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
-#include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -37,317 +40,305 @@
 
 #define LOG_COMPONENT Logger::LOG_RECORDING
 
-namespace malmo
-{
-    MissionRecord::MissionRecord(const MissionRecordSpec& spec) : spec(spec), is_closed(true)
-    {
-        if (spec.isRecording()) {
-            boost::uuids::random_generator gen;
-            boost::uuids::uuid temp_uuid = gen();
-            char *malmo_tmp_path = getenv("MALMO_TEMP_PATH");
-            if (malmo_tmp_path)
-                this->temp_dir = boost::filesystem::path(malmo_tmp_path);
-            else
-                this->temp_dir = boost::filesystem::path(".");
-            this->mission_id = boost::uuids::to_string(temp_uuid);
-            this->temp_dir = this->temp_dir / "mission_records" / this->mission_id;
-            this->mp4_path = (this->temp_dir / "video.mp4").string();
-            this->mp4_depth_path = (this->temp_dir / "depth_video.mp4").string();
-            this->mp4_luminance_path = (this->temp_dir / "luminance_video.mp4").string();
-            this->mp4_colourmap_path = (this->temp_dir / "colourmap_video.mp4").string();
-            this->observations_path = (this->temp_dir / "observations.txt").string();
-            this->rewards_path = (this->temp_dir / "rewards.txt").string();
-            this->commands_path = (this->temp_dir / "commands.txt").string();
-            this->mission_init_path = (this->temp_dir / "missionInit.xml").string();
-            this->mission_ended_path = (this->temp_dir / "missionEnded.xml").string();
-            bool created_tmp = false;
-            try {
-                created_tmp = boost::filesystem::create_directories(this->temp_dir);
-            }
-            catch (const std::exception& e) {
-                LOGERROR(LT("Unable to create temporary folder for recording "), this->temp_dir.string(), LT(": "), e.what());
-                std::cout << "Unable to create temporary folder for recording " << this->temp_dir.string() << ": " << e.what() << std::endl;
-                throw std::runtime_error("Check your MALMO_TEMP_PATH and try again.");
-            }
+using namespace std;
+using namespace boost::filesystem;
 
-            if (created_tmp) {
-                this->is_closed = false;
-            }
-            else {
-                LOGERROR(LT("Unable to create temporary folder for recording "), this->temp_dir.string());
-                throw std::runtime_error("Unable to create temporary folder for recording " + this->temp_dir.string() + ": check your MALMO_TEMP_PATH?");
-            }
-        }
+namespace malmo {
+  MissionRecord::MissionRecord(const MissionRecordSpec& spec)
+      : spec(spec), is_closed(true) {
+    if (spec.isRecording()) {
+      boost::uuids::random_generator gen;
+      boost::uuids::uuid temp_uuid = gen();
+      char* malmo_tmp_path = getenv("MALMO_TEMP_PATH");
+      if (malmo_tmp_path)
+        this->temp_dir = path(malmo_tmp_path);
+      else
+        this->temp_dir = path(".");
+      this->mission_id = boost::uuids::to_string(temp_uuid);
+      this->temp_dir = this->temp_dir / "mission_records" / this->mission_id;
+      this->mp4_path = (this->temp_dir / "video.mp4").string();
+      this->mp4_depth_path = (this->temp_dir / "depth_video.mp4").string();
+      this->mp4_luminance_path =
+          (this->temp_dir / "luminance_video.mp4").string();
+      this->mp4_colourmap_path =
+          (this->temp_dir / "colourmap_video.mp4").string();
+      this->observations_path = (this->temp_dir / "observations.txt").string();
+      this->rewards_path = (this->temp_dir / "rewards.txt").string();
+      this->commands_path = (this->temp_dir / "commands.txt").string();
+      this->mission_init_path = (this->temp_dir / "missionInit.xml").string();
+      this->mission_ended_path = (this->temp_dir / "missionEnded.xml").string();
+      bool created_tmp = false;
+      try {
+        created_tmp = create_directories(this->temp_dir);
+      }
+      catch (const exception& e) {
+        LOGERROR(LT("Unable to create temporary folder for recording "),
+                 this->temp_dir.string(),
+                 LT(": "),
+                 e.what());
+        cout << "Unable to create temporary folder for recording "
+             << this->temp_dir.string() << ": " << e.what() << endl;
+        throw runtime_error("Check your MALMO_TEMP_PATH and try again.");
+      }
+
+      if (created_tmp) {
+        this->is_closed = false;
+      }
+      else {
+        LOGERROR(LT("Unable to create temporary folder for recording "),
+                 this->temp_dir.string());
+        throw runtime_error("Unable to create temporary folder for recording " +
+                            this->temp_dir.string() +
+                            ": check your MALMO_TEMP_PATH?");
+      }
+    }
+  }
+
+  MissionRecord::~MissionRecord() {
+    try {
+      if (!this->is_closed) {
+        this->close();
+      }
+    }
+    catch (const exception& e) {
+      // we don't really want to assume that is safe to write to cout but can't
+      // have destructors throwing exceptions
+      cout << "Exception in closing of MissionRecord: " << e.what() << endl;
+      LOGERROR(LT("Exception in closing of MissionRecord: "), e.what());
+    }
+    catch (...) {
+      // we don't really want to assume that is safe to write to cout but can't
+      // have destructors throwing exceptions
+      cout << "Unknown exception in closing of MissionRecord." << endl;
+      LOGERROR(LT("Unknown exception in closing of MissionRecord."));
+    }
+  }
+
+  MissionRecord::MissionRecord(MissionRecord&& record)
+      : is_closed(record.is_closed), spec(record.spec),
+        commands_path(record.commands_path), mp4_path(record.mp4_path),
+        mp4_depth_path(record.mp4_depth_path),
+        mp4_luminance_path(record.mp4_luminance_path),
+        mp4_colourmap_path(record.mp4_colourmap_path),
+        observations_path(record.observations_path),
+        rewards_path(record.rewards_path),
+        mission_init_path(record.mission_init_path),
+        mission_ended_path(record.mission_ended_path),
+        temp_dir(record.temp_dir), mission_id(record.mission_id) {
+    record.spec = MissionRecordSpec();
+  }
+
+  MissionRecord& MissionRecord::operator=(MissionRecord&& record) {
+    if (this != &record) {
+      this->is_closed = record.is_closed;
+      this->spec = record.spec;
+      this->commands_path = record.commands_path;
+      this->mp4_path = record.mp4_path;
+      this->mp4_depth_path = record.mp4_depth_path;
+      this->mp4_luminance_path = record.mp4_luminance_path;
+      this->mp4_colourmap_path = record.mp4_colourmap_path;
+      this->observations_path = record.observations_path;
+      this->rewards_path = record.rewards_path;
+      this->mission_init_path = record.mission_init_path;
+      this->mission_ended_path = record.mission_ended_path;
+      this->temp_dir = record.temp_dir;
+      this->mission_id = record.mission_id;
+
+      record.spec = MissionRecordSpec();
     }
 
-    MissionRecord::~MissionRecord()
-    {
-        try {
-            if (!this->is_closed) {
-                this->close();
-            }
+    return *this;
+  }
 
-        }
-        catch (const std::exception& e) {
-            // we don't really want to assume that is safe to write to cout but can't have destructors throwing exceptions
-            std::cout << "Exception in closing of MissionRecord: " << e.what() << std::endl;
-            LOGERROR(LT("Exception in closing of MissionRecord: "), e.what());
-        }
-        catch(...) {
-            // we don't really want to assume that is safe to write to cout but can't have destructors throwing exceptions
-            std::cout << "Unknown exception in closing of MissionRecord." << std::endl;
-            LOGERROR(LT("Unknown exception in closing of MissionRecord."));
-        }
+  void MissionRecord::close() {
+    if (!this->spec.isRecording() || this->is_closed) {
+      return;
     }
 
-    MissionRecord::MissionRecord(MissionRecord&& record)
-        : is_closed(record.is_closed)
-        , spec(record.spec)
-        , commands_path(record.commands_path)
-        , mp4_path(record.mp4_path)
-        , mp4_depth_path(record.mp4_depth_path)
-        , mp4_luminance_path(record.mp4_luminance_path)
-        , mp4_colourmap_path(record.mp4_colourmap_path)
-        , observations_path(record.observations_path)
-        , rewards_path(record.rewards_path)
-        , mission_init_path(record.mission_init_path)
-        , mission_ended_path(record.mission_ended_path)
-        , temp_dir(record.temp_dir)
-        , mission_id(record.mission_id)
-    {
-        record.spec = MissionRecordSpec();
-    }
+    LOGSECTION(LOG_INFO, LT("Closing MissionRecord..."));
+    // create zip file, push to destination
+    vector<path> fileList;
+    this->addFiles(fileList, this->temp_dir);
+    LOGINFO(LT("Found "), fileList.size(), LT(" files to tar:"));
 
-    MissionRecord& MissionRecord::operator=(MissionRecord&& record)
-    {
-        if (this != &record){
-            this->is_closed = record.is_closed;
-            this->spec = record.spec;
-            this->commands_path = record.commands_path;
-            this->mp4_path = record.mp4_path;
-            this->mp4_depth_path = record.mp4_depth_path;
-            this->mp4_luminance_path = record.mp4_luminance_path;
-            this->mp4_colourmap_path = record.mp4_colourmap_path;
-            this->observations_path = record.observations_path;
-            this->rewards_path = record.rewards_path;
-            this->mission_init_path = record.mission_init_path;
-            this->mission_ended_path = record.mission_ended_path;
-            this->temp_dir = record.temp_dir;
-            this->mission_id = record.mission_id;
+    if (fileList.size() > 0) {
+      std::ofstream file(this->spec.destination, std::ofstream::binary);
+      if (file.fail()) {
+        cout << "[warning] Unable to write recording to output file "
+             << this->spec.destination << endl;
+        LOGERROR(LT("Unable to write recording to output file "),
+                 this->spec.destination);
+      }
+      else {
+        boost::iostreams::filtering_ostream out;
+        out.push(boost::iostreams::gzip_compressor());
+        out.push(file);
+        lindenb::io::Tar tarball(out);
 
-            record.spec = MissionRecordSpec();
-        }
-
-        return *this;
-    }
-
-    void MissionRecord::close()
-    {
-        if (!this->spec.isRecording() || this->is_closed){
-            return;
-        }
-
-        LOGSECTION(LOG_INFO, LT("Closing MissionRecord..."));
-        // create zip file, push to destination
-        std::vector<boost::filesystem::path> fileList;
-        this->addFiles(fileList, this->temp_dir);
-        LOGINFO(LT("Found "), fileList.size(), LT(" files to tar:"));
-
-        if (fileList.size() > 0){
-            std::ofstream file(this->spec.destination, std::ofstream::binary);
-            if (file.fail()) {
-                std::cout << "[warning] Unable to write recording to output file " << this->spec.destination << std::endl;
-                LOGERROR(LT("Unable to write recording to output file "), this->spec.destination);
-            }
-            else {
-                boost::iostreams::filtering_ostream out;
-                out.push(boost::iostreams::gzip_compressor());
-                out.push(file);
-                lindenb::io::Tar tarball(out);
-
-                for (auto file : fileList){
-                    try{
-                        this->addFile(tarball, file);
-                    }
-                    catch (const std::exception& e){
-                        std::cout << "[warning] Unable to archive " << file.string() << ": " << e.what() << std::endl;
-                        LOGERROR(LT("Unable to archive "), file.string(), LT(": "), e.what());
-                    }
-                }
-
-                tarball.finish();
-                if (!out.good()) {
-                    std::cout << "[warning] tar file corrupted." << std::endl;
-                    LOGERROR(LT("Tar file corrupted."));
-                }
-            }
-        }
-        LOGINFO(LT("Deleting MissionRecord temp folder."));
-        boost::filesystem::remove_all(this->temp_dir);
-
-        this->is_closed = true;
-    }
-
-    void MissionRecord::addFiles(std::vector<boost::filesystem::path> &fileList, boost::filesystem::path directory)
-    {
-        if (!boost::filesystem::exists(directory))
-        {
-            LOGERROR(LT("Attempt to write to non-existent directory: "), directory.string());
-            throw std::runtime_error("Attempt to write to non-existent directory: " + directory.string());
-        }
-        boost::filesystem::directory_iterator dirIter(directory);
-        boost::filesystem::directory_iterator dirIterEnd;
-
-        while (dirIter != dirIterEnd)
-        {
-            if (boost::filesystem::exists(*dirIter))
-            {
-                if (boost::filesystem::is_directory(*dirIter)){
-                    this->addFiles(fileList, *dirIter);
-                }
-                else
-                {
-                    fileList.push_back((*dirIter));
-                }
-            }
-        
-            ++dirIter;
-        }
-    }
-
-    void MissionRecord::addFile(lindenb::io::Tar& archive, boost::filesystem::path path)
-    {
-        // boost::filesystem::relative would do what we want here, but it wasn't introduced until boost 1.60, and
-        // we still want to support operating systems with older versions.
-        boost::filesystem::path filepath = boost::filesystem::absolute(path);
-        boost::filesystem::path tempdirpath = boost::filesystem::absolute(this->temp_dir);
-        boost::filesystem::path::iterator it_file = filepath.begin();
-        boost::filesystem::path::iterator it_tmpdir = tempdirpath.begin();
-        boost::filesystem::path relpath = this->mission_id; // Start with the mission_id as our root.
-        // Skip everything which is in both paths:
-        while (*it_file == *it_tmpdir && it_file != filepath.end() && it_tmpdir != tempdirpath.end())
-        {
-            it_file++, it_tmpdir++;
-        }
-        // Now get rest of file path:
-        for (; it_file != filepath.end(); it_file++)
-        {
-            relpath /= *it_file;
-        }
-        std::string file_name_in_archive = relpath.normalize().string();
-        std::replace(file_name_in_archive.begin(), file_name_in_archive.end(), '\\', '/');
-        LOGINFO(LT("- adding "), path.string(), LT(" as "), file_name_in_archive);
-        archive.putFile(path.string().c_str(), file_name_in_archive.c_str());
-    }
-
-    bool MissionRecord::isRecording() const
-    {
-        return this->spec.isRecording();
-    }
-
-    bool MissionRecord::isRecordingObservations() const
-    {
-        return this->spec.is_recording_observations;
-    }
-
-    bool MissionRecord::isRecordingRewards() const
-    {
-        return this->spec.is_recording_rewards;
-    }
-
-    bool MissionRecord::isRecordingCommands() const
-    {
-        return this->spec.is_recording_commands;
-    }
-
-    std::string MissionRecord::getMP4Path() const
-    {
-        return this->mp4_path;
-    }
-
-    std::string MissionRecord::getMP4DepthPath() const
-    {
-        return this->mp4_depth_path;
-    }
-
-    std::string MissionRecord::getMP4LuminancePath() const
-    {
-        return this->mp4_luminance_path;
-    }
-
-    std::string MissionRecord::getMP4ColourMapPath() const
-    {
-        return this->mp4_colourmap_path;
-    }
-
-    int64_t MissionRecord::getMP4BitRate(TimestampedVideoFrame::FrameType type) const
-    {
-        auto it = this->spec.video_recordings.find(type);
-        return (it != this->spec.video_recordings.end()) ? it->second.mp4_bit_rate : 0;
-    }
-
-    int MissionRecord::getMP4FramesPerSecond(TimestampedVideoFrame::FrameType type) const
-    {
-        auto it = this->spec.video_recordings.find(type);
-        return (it != this->spec.video_recordings.end()) ? it->second.mp4_fps : 0;
-    }
-
-    bool MissionRecord::isDroppingFrames(TimestampedVideoFrame::FrameType type) const
-    {
-        auto it = this->spec.video_recordings.find(type);
-        return it == this->spec.video_recordings.end() || it->second.drop_input_frames;
-    }
-
-    bool MissionRecord::isRecordingMP4(TimestampedVideoFrame::FrameType type) const
-    {
-        auto it = this->spec.video_recordings.find(type);
-        return it != this->spec.video_recordings.end() && it->second.fr_type == MissionRecordSpec::VIDEO;
-    }
-
-    bool MissionRecord::isRecordingBmps(TimestampedVideoFrame::FrameType type) const
-    {
-        auto it = this->spec.video_recordings.find(type);
-        return it != this->spec.video_recordings.end() && it->second.fr_type == MissionRecordSpec::BMP;
-    }
-
-    std::string MissionRecord::getObservationsPath() const
-    {
-        return this->observations_path;
-    }
-
-    std::string MissionRecord::getRewardsPath() const
-    {
-        return this->rewards_path;
-    }
-
-    std::string MissionRecord::getCommandsPath() const
-    {
-        return this->commands_path;
-    }
-
-    std::string MissionRecord::getMissionInitPath() const
-    {
-        return this->mission_init_path;
-    }
-
-    std::string MissionRecord::getMissionEndedPath() const
-    {
-        return this->mission_ended_path;
-    }
-
-    std::string MissionRecord::getTemporaryDirectory() const
-    {
-        if (!this->spec.isRecording()){
-            throw std::runtime_error("Mission is not being recorded.");
+        for (auto file : fileList) {
+          try {
+            this->addFile(tarball, file);
+          }
+          catch (const exception& e) {
+            cout << "[warning] Unable to archive " << file.string() << ": "
+                 << e.what() << endl;
+            LOGERROR(
+                LT("Unable to archive "), file.string(), LT(": "), e.what());
+          }
         }
 
-        if (boost::filesystem::exists(this->temp_dir)){
-            return this->temp_dir.string();
+        tarball.finish();
+        if (!out.good()) {
+          cout << "[warning] tar file corrupted." << endl;
+          LOGERROR(LT("Tar file corrupted."));
         }
-        else{
-            throw std::runtime_error("Mission record does not yet exist. Temporary directory will be created once a mission has begun.");
-        }
+      }
     }
-}
+    LOGINFO(LT("Deleting MissionRecord temp folder."));
+    remove_all(this->temp_dir);
+
+    this->is_closed = true;
+  }
+
+  void MissionRecord::addFiles(vector<path>& fileList, path directory) {
+    if (!exists(directory)) {
+      LOGERROR(LT("Attempt to write to non-existent directory: "),
+               directory.string());
+      throw runtime_error("Attempt to write to non-existent directory: " +
+                          directory.string());
+    }
+    directory_iterator dirIter(directory);
+    directory_iterator dirIterEnd;
+
+    while (dirIter != dirIterEnd) {
+      if (exists(*dirIter)) {
+        if (is_directory(*dirIter)) {
+          this->addFiles(fileList, *dirIter);
+        }
+        else {
+          fileList.push_back((*dirIter));
+        }
+      }
+
+      ++dirIter;
+    }
+  }
+
+  void MissionRecord::addFile(lindenb::io::Tar& archive, path filepath) {
+    // relative would do what we want here, but it wasn't
+    // introduced until boost 1.60, and we still want to support operating
+    // systems with older versions.
+    path abspath = absolute(filepath);
+    path tempdirpath = absolute(this->temp_dir);
+    path::iterator it_file = abspath.begin();
+    path::iterator it_tmpdir = tempdirpath.begin();
+    path relpath = this->mission_id; // Start with the mission_id as our root.
+    // Skip everything which is in both paths:
+    while (*it_file == *it_tmpdir && it_file != abspath.end() &&
+           it_tmpdir != tempdirpath.end()) {
+      it_file++, it_tmpdir++;
+    }
+    // Now get rest of file path:
+    for (; it_file != abspath.end(); it_file++) {
+      relpath /= *it_file;
+    }
+    string file_name_in_archive = relpath.normalize().string();
+    replace(
+        file_name_in_archive.begin(), file_name_in_archive.end(), '\\', '/');
+    LOGINFO(LT("- adding "), filepath.string(), LT(" as "), file_name_in_archive);
+    archive.putFile(filepath.string().c_str(), file_name_in_archive.c_str());
+  }
+
+  bool MissionRecord::isRecording() const { return this->spec.isRecording(); }
+
+  bool MissionRecord::isRecordingObservations() const {
+    return this->spec.is_recording_observations;
+  }
+
+  bool MissionRecord::isRecordingRewards() const {
+    return this->spec.is_recording_rewards;
+  }
+
+  bool MissionRecord::isRecordingCommands() const {
+    return this->spec.is_recording_commands;
+  }
+
+  string MissionRecord::getMP4Path() const { return this->mp4_path; }
+
+  string MissionRecord::getMP4DepthPath() const { return this->mp4_depth_path; }
+
+  string MissionRecord::getMP4LuminancePath() const {
+    return this->mp4_luminance_path;
+  }
+
+  string MissionRecord::getMP4ColourMapPath() const {
+    return this->mp4_colourmap_path;
+  }
+
+  int64_t
+  MissionRecord::getMP4BitRate(TimestampedVideoFrame::FrameType type) const {
+    auto it = this->spec.video_recordings.find(type);
+    return (it != this->spec.video_recordings.end()) ? it->second.mp4_bit_rate
+                                                     : 0;
+  }
+
+  int MissionRecord::getMP4FramesPerSecond(
+      TimestampedVideoFrame::FrameType type) const {
+    auto it = this->spec.video_recordings.find(type);
+    return (it != this->spec.video_recordings.end()) ? it->second.mp4_fps : 0;
+  }
+
+  bool
+  MissionRecord::isDroppingFrames(TimestampedVideoFrame::FrameType type) const {
+    auto it = this->spec.video_recordings.find(type);
+    return it == this->spec.video_recordings.end() ||
+           it->second.drop_input_frames;
+  }
+
+  bool
+  MissionRecord::isRecordingMP4(TimestampedVideoFrame::FrameType type) const {
+    auto it = this->spec.video_recordings.find(type);
+    return it != this->spec.video_recordings.end() &&
+           it->second.fr_type == MissionRecordSpec::VIDEO;
+  }
+
+  bool
+  MissionRecord::isRecordingBmps(TimestampedVideoFrame::FrameType type) const {
+    auto it = this->spec.video_recordings.find(type);
+    return it != this->spec.video_recordings.end() &&
+           it->second.fr_type == MissionRecordSpec::BMP;
+  }
+
+  string MissionRecord::getObservationsPath() const {
+    return this->observations_path;
+  }
+
+  string MissionRecord::getRewardsPath() const { return this->rewards_path; }
+
+  string MissionRecord::getCommandsPath() const { return this->commands_path; }
+
+  string MissionRecord::getMissionInitPath() const {
+    return this->mission_init_path;
+  }
+
+  string MissionRecord::getMissionEndedPath() const {
+    return this->mission_ended_path;
+  }
+
+  string MissionRecord::getTemporaryDirectory() const {
+    if (!this->spec.isRecording()) {
+      throw runtime_error("Mission is not being recorded.");
+    }
+
+    if (exists(this->temp_dir)) {
+      return this->temp_dir.string();
+    }
+    else {
+      throw runtime_error(
+          "Mission record does not yet exist. Temporary directory will be "
+          "created once a mission has begun.");
+    }
+  }
+} // namespace malmo
 
 #undef LOG_COMPONENT

--- a/external/malmo/Malmo/src/MissionSpec.cpp
+++ b/external/malmo/Malmo/src/MissionSpec.cpp
@@ -458,8 +458,7 @@ namespace malmo {
                       "");
   }
 
-  // ------------------ settings for the agents : command handlers
-  // --------------------------------
+  // Settings for the agents : command handlers
 
   void MissionSpec::removeAllCommandHandlers() {
     const auto& agent_handlers =

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -30,7 +30,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
       gradle \
       libsndfile \
       portaudio
-    sudo port install boost -no_static
+    if ! port installed | grep -q boost; then
+      sudo port install boost -no_static
+    fi
 
     # Check if JAVA_HOME is set to Java 8
     if ! [[ "$JAVA_HOME" == "/Library/Java/JavaVirtualMachines/openjdk8/Contents/Home" ]]; then


### PR DESCRIPTION
This PR:

* Cleans up Malmo code a bit, adding `this->` to explicitly point out class membership, and also auto formatting using `clang-format`.
* Adds a script, `upload_to_vanga`, that can be used to upload tomcat data to vanga.sista.arizona.edu so that it can be downloaded by the public. See comments in the script for instructions on usage.