### PR TITLE
Updating Travis config and installation scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 
 script:
   - ./tools/download_tomcat_data.sh
+  - ./tools/install_dependencies.sh
   - mkdir build && cd build && cmake .. -DBUILD_DOCS=ON && make -j test && cd ../
   - cd build && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml && cd ../
   - cd build && make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - cd build && make -j test 
              && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml 
              && cd ../
-  - cd ${TOMCAT}/build && make docs && cd $TOMCAT
+  - cd ${TOMCAT}/build && make docs && cd ../
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ language:
  - cpp
  - python
 
+addons:
+  homebrew:
+    packages:
+    - lcov
+
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 -m venv tomcat; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source tomcat/bin/activate; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,7 @@ language:
 addons:
   homebrew:
     packages:
-      - graphviz
-      - cmake
-      - boost
-      - doxygen
-      - opencv
-      - fmt
-      - ffmpeg
-      - openblas
       - lcov
-      - portaudio
-      - libsndfile
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 -m venv tomcat; fi
@@ -28,14 +18,13 @@ before_install:
 
 install:
   - pip install exhale recommonmark sphinx-rtd-theme
-  - cd external && curl -O http://dlib.net/files/dlib-19.17.tar.bz2 
-    && tar -xvjf dlib-19.17.tar.bz2 && cd ../
 
 env:
   - TOMCAT=$TRAVIS_BUILD_DIR
 
 script:
   - ./tools/download_tomcat_data.sh
+  - ./tools/install_dependencies.sh
   - mkdir build && cd build && cmake .. -DBUILD_DOCS=ON && make -j test && cd ../
   - cd build && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml && cd ../
   - cd build && make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,15 @@ before_install:
 install:
   - pip install exhale recommonmark sphinx-rtd-theme
   - cd external && curl -O http://dlib.net/files/dlib-19.17.tar.bz2 
-    && tar -xvjf dlib-19.17.tar.bz2 && cd ../
+                && tar -xvjf dlib-19.17.tar.bz2 
 
 env:
   - TOMCAT=$TRAVIS_BUILD_DIR
 
 script:
-  - ./tools/download_tomcat_data.sh
-  - ./tools/install_dependencies.sh
-  - mkdir build && cd build && cmake .. -DBUILD_DOCS=ON && make -j test && cd ../
-  - cd build && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml && cd ../
+  - ./tools/install.sh
+  - cd build && make -j test 
+             && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml 
   - cd build && make docs
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ language:
  - cpp
  - python
 
-addons:
-  homebrew:
-    packages:
-      - lcov
-
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 -m venv tomcat; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source tomcat/bin/activate; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - TOMCAT=$TRAVIS_BUILD_DIR
 
 script:
-  - ./tools/install.sh
+  - cd $TOMCAT && ./tools/install.sh && cd $TOMCAT
   - cd build && make -j test 
              && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml 
              && cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ before_install:
 
 install:
   - pip install exhale recommonmark sphinx-rtd-theme
+  - cd external && curl -O http://dlib.net/files/dlib-19.17.tar.bz2 
+    && tar -xvjf dlib-19.17.tar.bz2 && cd ../
 
 env:
   - TOMCAT=$TRAVIS_BUILD_DIR
 
 script:
   - ./tools/download_tomcat_data.sh
-  - ./tools/install_dependencies.sh
   - mkdir build && cd build && cmake .. -DBUILD_DOCS=ON && make -j test && cd ../
   - cd build && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml && cd ../
   - cd build && make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - cd build && make -j test 
              && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml 
              && cd ../
-  - cd build && make docs
+  - cd ${TOMCAT}/build && make docs && cd $TOMCAT
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
 install:
   - pip install exhale recommonmark sphinx-rtd-theme
   - cd external && curl -O http://dlib.net/files/dlib-19.17.tar.bz2 
-                && tar -xvjf dlib-19.17.tar.bz2 
+                && tar -xvjf dlib-19.17.tar.bz2
+                && cd ../
 
 env:
   - TOMCAT=$TRAVIS_BUILD_DIR
@@ -28,6 +29,7 @@ script:
   - ./tools/install.sh
   - cd build && make -j test 
              && ./bin/test --mission ../external/malmo/sample_missions/default_world_1.xml 
+             && cd ../
   - cd build && make docs
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
   - pip install exhale recommonmark sphinx-rtd-theme
-  - cd external && curl -O http://dlib.net/files/dlib-19.17.tar.bz2 
+  - cd $TOMCAT/external && curl -O http://dlib.net/files/dlib-19.17.tar.bz2 
                 && tar -xvjf dlib-19.17.tar.bz2
                 && cd ../
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,6 @@ endif()
 add_subdirectory(external/malmo)
 add_subdirectory(external/OpenFace)
 
-if(DEFINED ENV{TRAVIS})
-  option(CODE_COVERAGE "Enable coverage reporting" ON)
-endif()
 
 add_subdirectory(src)
 target_include_directories(tomcat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,12 @@ find_package(PortAudio)
 find_package(LibSndFile)
 
 
-#if(DEFINED ENV{TRAVIS})
-  #message("-- CMake running on Travis, using downloaded dlib.")
-  #add_subdirectory(external/dlib-19.17)
-#else()
-  #find_package(dlib REQUIRED)
-#endif()
+if(DEFINED ENV{TRAVIS})
+  message("-- CMake running on Travis, using downloaded dlib.")
+  add_subdirectory(external/dlib-19.17)
+else()
+  find_package(dlib REQUIRED)
+endif()
 
 add_subdirectory(external/malmo)
 add_subdirectory(external/OpenFace)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,12 @@ find_package(PortAudio)
 find_package(LibSndFile)
 
 
-if(DEFINED ENV{TRAVIS})
-  message("-- CMake running on Travis, using downloaded dlib.")
-  add_subdirectory(external/dlib-19.17)
-else()
-  find_package(dlib REQUIRED)
-endif()
+#if(DEFINED ENV{TRAVIS})
+  #message("-- CMake running on Travis, using downloaded dlib.")
+  #add_subdirectory(external/dlib-19.17)
+#else()
+  #find_package(dlib REQUIRED)
+#endif()
 
 add_subdirectory(external/malmo)
 add_subdirectory(external/OpenFace)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,14 +34,14 @@ if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   message("Building with code coverage")
   target_compile_options(
     tomcat
-    PRIVATE -O0 # no optimization
+    PUBLIC -O0 # no optimization
             -g # generate debug info
             --coverage # sets all required flags
   )
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-    target_link_options(tomcat PRIVATE --coverage)
+    target_link_options(tomcat PUBLIC --coverage)
   else()
-    target_link_libraries(tomcat PRIVATE --coverage)
+    target_link_libraries(tomcat PUBLIC --coverage)
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,11 @@ target_link_libraries(
   ${LIBSNDFILE_LIBRARIES}
   fmt::fmt)
 
+if(DEFINED ENV{TRAVIS})
+  option(CODE_COVERAGE "Enable coverage reporting" ON)
+  message("Compilation occurring on Travis, code coverage reporting on.")
+endif()
+
 if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   # Add required flags (GCC & LLVM/Clang)
   message("Building with code coverage")

--- a/src/Microphone.cpp
+++ b/src/Microphone.cpp
@@ -1,4 +1,5 @@
 #include "Microphone.h"
+#include <fmt/format.h>
 
 using namespace std;
 using namespace fmt::literals;

--- a/src/Microphone.h
+++ b/src/Microphone.h
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <fmt/format.h>
 #include <sndfile.hh>
 
 #define SAMPLE_SILENCE (0.0f)

--- a/src/runExperiment.cpp
+++ b/src/runExperiment.cpp
@@ -1,6 +1,5 @@
 #include "LocalAgent.h"
 #include <boost/program_options.hpp>
-#include <fmt/format.h>
 #include <string>
 
 int main(int argc, const char* argv[]) {

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -7,7 +7,7 @@ tomcat=`echo $script_path | sed 's#^\./##' | sed 's#^\(.*\)//*tools/*install.sh#
 # We do not actually need to consult TOMCAT as an environment variable, but it
 # gives us a chance to remind the the user that we are ignoring their location
 # hint. 
-#
+
 if [ ! -z "$TOMCAT" ]; then
     if [[ "${TOMCAT}" != "${tomcat}" ]]; then
         echo "Resetting TOMCAT variable from ${TOMCAT} to ${tomcat}."
@@ -31,7 +31,13 @@ pushd "${TOMCAT}"
 
     pushd build > /dev/null 
 
-    cmake ${TOMCAT}
+    if [[ ! -z $TRAVIS ]]; then
+      cmake ${TOMCAT}
+    else
+      # On Travis, we will build HTML documentation by default.
+      cmake ${TOMCAT} -DBUILD_DOCS=ON
+    fi;
+
     if [[ $? -ne 0 ]]; then exit 1; fi;
 
     make -j

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -43,7 +43,12 @@ pushd "${TOMCAT}"
     make -j
     if [[ $? -ne 0 ]]; then exit 1; fi;
 
-    make -j Minecraft
+    # We skip building Minecraft on Travis since we cannot get an
+    # appropriate version of Java on their MacOS image.
+    if [[ -z $TRAVIS ]]; then
+      make -j Minecraft
+    fi
+
     if [[ $? -ne 0 ]]; then exit 1; fi;
 popd > /dev/null 
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -32,10 +32,10 @@ pushd "${TOMCAT}"
     pushd build > /dev/null 
 
     if [[ ! -z $TRAVIS ]]; then
-      cmake ${TOMCAT}
-    else
       # On Travis, we will build HTML documentation by default.
       cmake ${TOMCAT} -DBUILD_DOCS=ON
+    else
+      cmake ${TOMCAT}
     fi;
 
     if [[ $? -ne 0 ]]; then exit 1; fi;

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -56,6 +56,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
         sudo port install boost -no_static
         if [[ $? -ne 0 ]]; then exit 1; fi;
+
     elif [ -x "$(command -v brew)" ]; then
         echo "\'brew\' executable detected, assuming that Homebrew"\
         "\(https://brew.sh\) is installed and is the package manager."
@@ -79,7 +80,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
 
-        if [[ ! -z $TRAVIS ]]
+        if [[ ! -z $TRAVIS ]]; then
           brew install dlib
         else
           echo("This script is running on Travis CI, so we will not install dlib using Homebrew.")

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -86,7 +86,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         if [[ ! -z $TRAVIS ]]; then
           # If we are running this installation on Travis, we will also install
           # lcov for code coverage measurement.
-          brew install lcov
+          #brew install lcov
+          echo "Not installing dlib through Homebrew."
         else
           brew install dlib
         fi;

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -66,6 +66,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         brew update
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
+        # We do not check exit codes for Homebrew installs since `brew install`
+        # can return an exit code of 1 when a package is already installed (!!)
+
         brew install \
           cmake \
           fmt \
@@ -77,26 +80,22 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
           libsndfile \
           portaudio
 
-        echo "Exit code from brew install is $?"
-        if [[ $? -ne 0 ]]; then exit 1; fi;
-
-
+        # The Homebrew install of DLib on Travis doesn't play well with CMake
+        # for some reason, so we install DLib on Travis from source rather than
+        # with the Homebrew package manager.
         if [[ ! -z $TRAVIS ]]; then
           brew install dlib
-          if [[ $? -ne 0 ]]; then exit 1; fi;
         else
-          echo "This script is running on Travis CI, so we will not install dlib using Homebrew."
+          # If we are running this installation on Travis, we will also install
+          # lcov for code coverage measurement.
+          brew install lcov
         fi;
 
         # Installing Java
         brew tap adoptopenjdk/openjdk
-        if [[ $? -ne 0 ]]; then exit 1; fi;
-
         brew cask install adoptopenjdk8
-        if [[ $? -ne 0 ]]; then exit 1; fi;
-
         brew install gradle
-        if [[ $? -ne 0 ]]; then exit 1; fi;
+
     else 
         echo "No package manager found for $OSTYPE"
         exit 1 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -84,11 +84,11 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         # for some reason, so we install DLib on Travis from source rather than
         # with the Homebrew package manager.
         if [[ ! -z $TRAVIS ]]; then
-          brew install dlib
-        else
           # If we are running this installation on Travis, we will also install
           # lcov for code coverage measurement.
           brew install lcov
+        else
+          brew install dlib
         fi;
 
         # Installing Java

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -77,6 +77,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
           libsndfile \
           portaudio
 
+        echo "Exit code from brew install is $?"
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -6,21 +6,21 @@ echo "Checking OS."
 # If MacOS, then try MacPorts and Homebrew
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "MacOS detected. Checking for xcode developer kit."
+    echo "MacOS detected. Checking for XCode developer kit."
 
-    xcode_sdk_dir="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs"
-    if [[ ! -d "${xcode_sdk_dir}" ]]; then
-        echo "No xcode developer kit found. You need to get this from the app store."
+    XCode_sdk_dir="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs"
+    if [[ ! -d "${XCode_sdk_dir}" ]]; then
+        echo "No XCode developer kit found. You need to get this from the app store."
         exit 1 
     else 
-        if [[ ! -e "${xcode_sdk_dir}/MacOSX10.14.sdk" ]]; then
-            if [[ ! -e "${xcode_sdk_dir}/MacOSX.sdk" ]]; then
-                echo "No MacOSX.sdk in ${xcode_sdk_dir}."
+        if [[ ! -e "${XCode_sdk_dir}/MacOSX10.14.sdk" ]]; then
+            if [[ ! -e "${XCode_sdk_dir}/MacOSX.sdk" ]]; then
+                echo "No MacOSX.sdk in ${XCode_sdk_dir}."
                 echo "Possibly MacOS has changed things (again)."
                 exit 1 
             else 
-                pushd "${xcode_sdk_dir}" > /dev/null
-                    echo "Linking missing MacOSX10.14.sdk to MacOSX.sdk in ${xcode_sdk_dir}/"
+                pushd "${XCode_sdk_dir}" > /dev/null
+                    echo "Linking missing MacOSX10.14.sdk to MacOSX.sdk in ${XCode_sdk_dir}/"
                     sudo ln -s "MacOSX.sdk" "MacOSX10.14.sdk" 
                     if [[ $? -ne 0 ]]; then exit 1; fi;
                 popd > /dev/null
@@ -28,7 +28,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         fi 
     fi 
   
-    echo "Found xcode developer kit."
+    echo "Found XCode developer kit."
     echo "Checking for MacPorts or Homebrew package managers."
   
     if [ -x "$(command -v port)" ]; then
@@ -72,13 +72,21 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
           ffmpeg \
           opencv \
           openblas \
-          dlib \
           boost \
           libsndfile \
           portaudio
 
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
+
+        if [[ ! -z $TRAVIS ]]
+          brew install dlib
+        else
+          echo("This script is running on Travis CI, so we will not install dlib using Homebrew.")
+        fi;
+        if [[ $? -ne 0 ]]; then exit 1; fi;
+
+        # Installing Java
         brew tap adoptopenjdk/openjdk
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
@@ -114,7 +122,7 @@ elif [ -x "$(command -v apt-get)" ]; then
         libsndfile1-dev
     if [[ $? -ne 0 ]]; then exit 1; fi;
 else 
-    echo "This is not a mac and not Ubuntu (at least apt-get is not around). We cannot proceed."
+    echo "This is not a Mac and not Ubuntu (at least apt-get is not around). We cannot proceed."
     exit 1 
 fi
 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -83,7 +83,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         if [[ ! -z $TRAVIS ]]; then
           brew install dlib
         else
-          echo("This script is running on Travis CI, so we will not install dlib using Homebrew.")
+          echo "This script is running on Travis CI, so we will not install dlib using Homebrew."
         fi;
         if [[ $? -ne 0 ]]; then exit 1; fi;
 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -82,10 +82,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
         if [[ ! -z $TRAVIS ]]; then
           brew install dlib
+          if [[ $? -ne 0 ]]; then exit 1; fi;
         else
           echo "This script is running on Travis CI, so we will not install dlib using Homebrew."
         fi;
-        if [[ $? -ne 0 ]]; then exit 1; fi;
 
         # Installing Java
         brew tap adoptopenjdk/openjdk

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -84,9 +84,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         # for some reason, so we install DLib on Travis from source rather than
         # with the Homebrew package manager.
         if [[ ! -z $TRAVIS ]]; then
-          # If we are running this installation on Travis, we will also install
-          # lcov for code coverage measurement.
-          #brew install lcov
           echo "Not installing dlib through Homebrew."
         else
           brew install dlib


### PR DESCRIPTION
This PR moves the Homebrew package installations from being defined in `.travis.yml` to `tools/install.sh`, for better debugging (this way the Travis build runs with the same command as the end user build, which is good for debugging purposes.