### PR TITLE
Adding an if statement to only require C++17 with macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,12 @@ cmake_minimum_required(VERSION 3.15)
 project(tomcat)
 
 if(NOT DEFINED ENV{TRAVIS})
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  # Deal with C++17 warnings on macOS. Ubuntu's DLib available through apt-get
+  # doesn't adhere to the C++17 standard unfortunately.
+  if (APPLE)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  endif()
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/")


### PR DESCRIPTION
This PR updates CMakeLists.txt to enforce the C++17 standard only on MacOS (so that warnings about multiple using directives are suppressed). On Ubuntu, this breaks compilation since the version of dlib obtained with apt-get doesn't comply with the standard.