### PR TITLE
View modes client server separation

### DIFF
--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Messaging/TomcatMessaging.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Messaging/TomcatMessaging.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.relauncher.Side;
 public class TomcatMessaging {
 
 	public enum TomcatMessageType { SHOW_COMPLETION_SCREEN, SHOW_INSTRUCTIONS_SCREEN, SHOW_MESSAGE_SCREEN, VILLAGER_SAVED, 
-		OPEN_SCREEN_DISMISSED, DISMISS_OPEN_SCREEN };
+		OPEN_SCREEN_DISMISSED, DISMISS_OPEN_SCREEN, VIEW_CHANGED };
 
 
 	public static class TomcatMessage implements IMessage {

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Client/TutorialClientMission.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Client/TutorialClientMission.java
@@ -3,6 +3,7 @@ package edu.arizona.tomcat.Mission.Client;
 import edu.arizona.tomcat.Messaging.TomcatMessaging.TomcatMessage;
 import edu.arizona.tomcat.Mission.TutorialMission;
 import edu.arizona.tomcat.Mission.gui.GUIOverlayVillagersSaved;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
 
 public class TutorialClientMission extends ClientMission {
@@ -21,8 +22,16 @@ public class TutorialClientMission extends ClientMission {
 		switch (message.getMessageType()) {
 		case VILLAGER_SAVED:
 			this.numberOfSavedVillagers++;
-			break;	
+			break;
 
+			case VIEW_CHANGED:
+			if (Minecraft.getMinecraft().gameSettings.thirdPersonView < 2) {
+				Minecraft.getMinecraft().gameSettings.thirdPersonView++;
+			}
+			else {
+				Minecraft.getMinecraft().gameSettings.thirdPersonView = 0;
+			}
+				break;
 		default:
 			break;
 		}		

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Client/TutorialClientMission.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Client/TutorialClientMission.java
@@ -39,7 +39,6 @@ public class TutorialClientMission extends ClientMission {
 
 	/**
 	 * Retrieves the total number of villagers saved by the player
-	 * @param numberOfSavedVillagers - Total number of rescued villagers
 	 */
 	public int getNumberOfSavedVillagers() {
 		return this.numberOfSavedVillagers;

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/TutorialMission.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/TutorialMission.java
@@ -74,7 +74,7 @@ public class TutorialMission extends Mission {
 	 */
 	private void addApproachPoolsPhase() {
 		RichContent instructions = RichContent.createFromJson("tutorial_instructions1.json");
-		MissionPhase approachPoolsPhase = new MissionPhase(instructions, CompletionStrategy.ALL_GOALS, 10, true, "Well Done!", 0, 2);
+		MissionPhase approachPoolsPhase = new MissionPhase(instructions, CompletionStrategy.ALL_GOALS, 5, true, "Well Done!", 0, 2);
 		approachPoolsPhase.addGoal(new ReachPositionGoal(-635, 4, 1582, 2));
 		this.addPhase(approachPoolsPhase);
 	}
@@ -157,25 +157,37 @@ public class TutorialMission extends Mission {
 			this.shouldSpawnVillagerInsideTheBuilding = false;
 		}
 
-		/* viewTime is in seconds. The player stays in each view mode for 3 seconds.
-		 20 Minecraft ticks equal 1 real second. viewTime is incremented by 0.05 till 60 such ticks (3 seconds)
-		 have passed for each view */
-
-		if (this.viewTime < 3.00) {
-			Minecraft.getMinecraft().gameSettings.thirdPersonView = 2; // third person front view
-			this.viewTime += 0.05;
-		}
-		else if(this.viewTime < 6.00){
-		     Minecraft.getMinecraft().gameSettings.thirdPersonView = 3; // third person back view
-		     this.viewTime += 0.05;
-		}
-		else if (this.viewTime < 9.00) {
-			Minecraft.getMinecraft().gameSettings.thirdPersonView = 0; // first person view
-			this.viewTime = 10.00;
+		if (this.viewTime < 3.05) {
+			this.changePlayerPerspective();
 		}
 		//System.out.println("===========>Player's position: " + MinecraftServerHelper.getFirstPlayer().getPosition().toString());
 	}
-		
+
+	/**
+	 *  Cycles through Minecraft player perspectives
+	 */
+	private void changePlayerPerspective() {
+		/* viewTime is in seconds. The player stays in each view mode for 1.5 seconds.
+		 20 Minecraft ticks equal 1 real second. viewTime is incremented by 0.05 till 30 such ticks (1.5 second)
+		 have passed for each view */
+
+		double roundedTime = Math.round(this.viewTime*100.0)/100.0;
+
+		if (roundedTime == 0.00) {
+			MalmoMod.network.sendTo(new TomcatMessaging.TomcatMessage(TomcatMessageType.VIEW_CHANGED), MinecraftServerHelper.getFirstPlayer());
+		 	// third person back view
+		}
+		else if(roundedTime == 1.50){
+			MalmoMod.network.sendTo(new TomcatMessaging.TomcatMessage(TomcatMessageType.VIEW_CHANGED), MinecraftServerHelper.getFirstPlayer());
+			// third person front view
+		}
+		else if (roundedTime == 3.00) {
+			MalmoMod.network.sendTo(new TomcatMessaging.TomcatMessage(TomcatMessageType.VIEW_CHANGED), MinecraftServerHelper.getFirstPlayer());
+			// first person view
+		}
+		this.viewTime += 0.05;
+	}
+
 	/**
 	 * Spawn skeleton in the arena
 	 * @param world - Minecraft world


### PR DESCRIPTION
This PR implements some changes to the Tutorial Mission Views:

1) View change at the start of the tutorial mission is on the client side instead of the server (The server messages the client now). The server side logic was cleaned up a little and then abstracted into one function.

2) 3 seconds per view was very long, so the player now stays in each view mode for 1.5 seconds instead of 3. 

3) The Approach Pools Phase now starts at the 5th second instead of the 10th because the different views are now shown faster.
