### PR TITLE
Adding timestamps back after they were accidentally removed in PR #51

### DIFF
--- a/src/Mission.h
+++ b/src/Mission.h
@@ -69,7 +69,8 @@ namespace tomcat {
             bool record_commands,
             bool record_rewards,
             std::string record_path = "./saved_data.tgz",
-            std::string audio_record_path = "audio_recording.wav");
+            std::string audio_record_path = "audio_recording.wav"
+            );
 
     /**
      * Destructor


### PR DESCRIPTION
PR #51 accidentally removed the automatic timestamping of output data files. This PR adds them back.