### PR TITLE
Installation script refactoring

### DIFF
--- a/tools/download_OpenFace_models.sh
+++ b/tools/download_OpenFace_models.sh
@@ -10,7 +10,7 @@ pushd ${TOMCAT}/data > /dev/null
     # Download and extract the OpenFace models
     curl -O http://vision.cs.arizona.edu/adarsh/OpenFace_models.tgz
     if [[ $? -ne 0 ]]; then exit 1; fi;
-    tar -xvzf OpenFace_models.tgz && rm -rf OpenFace_models.tgz
+    tar -xvf OpenFace_models.tgz && rm -rf OpenFace_models.tgz
     if [[ $? -ne 0 ]]; then exit 1; fi;
 popd > /dev/null
 

--- a/tools/download_tomcat_worlds.sh
+++ b/tools/download_tomcat_worlds.sh
@@ -34,7 +34,7 @@ pushd ${TOMCAT}/data > /dev/null
     # Download and extract the manually-created worlds from vanga.
     curl -O http://vanga.sista.arizona.edu/tomcat/data/worlds.tgz
     if [[ $? -ne 0 ]]; then exit 1; fi;
-    tar -xvzf worlds.tgz && rm -rf worlds.tgz
+    tar -xzf worlds.tgz && rm -rf worlds.tgz
     if [[ $? -ne 0 ]]; then exit 1; fi;
 popd > /dev/null
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -25,7 +25,7 @@ else
     called_as_dir=`echo $called_as_dir | sed 's#^\(.*\)/.*$#\1#'`
     pushd "${called_as_dir}" > /dev/null; called_as_dir=`pwd`; popd > /dev/null
     export TOMCAT=`echo $called_as_dir | sed 's#^\./##' | sed 's#^\(.*\)/tools$#\1#'`
-    echo "Using inferreed TOMCAT location ${TOMCAT}."
+    echo "Using inferred TOMCAT location ${TOMCAT}."
 fi
 
 ###############################################################################

--- a/tools/install_boost_from_source.sh
+++ b/tools/install_boost_from_source.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Install Boost from source
+
+wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+tar xfz boost_1_71_0.tar.gz
+pushd boost_1_71_0
+  ./bootstrap.sh
+  if [[ $? -ne 0 ]]; then exit 1; fi;
+  sudo ./b2 install
+  if [[ $? -ne 0 ]]; then exit 1; fi;
+popd
+rm -rf boost_1_71_0*

--- a/tools/install_cmake_from_source.sh
+++ b/tools/install_cmake_from_source.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Install CMake from source
+
+install_cmake_from_source() {
+  local version=3.16
+  local build=2
+  local filename="cmake-$version.$build-Linux-x86_64.sh"
+  wget https://cmake.org/files/v$version/$filename
+  if [[ $? -ne 0 ]]; then exit 1; fi;
+  sudo sh $filename --prefix=/usr/local --skip-license
+  if [[ $? -ne 0 ]]; then exit 1; fi;
+  rm $filename
+  if [[ $? -ne 0 ]]; then exit 1; fi;
+}
+
+install_cmake_from_source

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -1,9 +1,21 @@
-#!/bin/bash 
+#!/bin/bash
 
 echo "Installing ToMCAT dependencies."
 
 echo "Checking OS."
 # If MacOS, then try MacPorts and Homebrew
+
+download_and_extract_dlib() {
+  pushd "${TOMCAT}/external"
+    # We download a specific commit snapshot of dlib from Github that
+    # contains a fix for the latest version of OpenCV that is being
+    # installed by Homebrew.
+    commit_sha=471c3d30e181a40942177a4358aa0496273d2108
+    curl -L https://github.com/davisking/dlib/archive/${commit_sha}.zip -o dlib.zip
+    unzip dlib.zip
+    mv dlib-${commit_sha} dlib
+  popd
+}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "MacOS detected. Checking for XCode developer kit."
@@ -11,36 +23,36 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     XCode_sdk_dir="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs"
     if [[ ! -d "${XCode_sdk_dir}" ]]; then
         echo "No XCode developer kit found. You need to get this from the app store."
-        exit 1 
-    else 
+        exit 1
+    else
         if [[ ! -e "${XCode_sdk_dir}/MacOSX10.14.sdk" ]]; then
             if [[ ! -e "${XCode_sdk_dir}/MacOSX.sdk" ]]; then
                 echo "No MacOSX.sdk in ${XCode_sdk_dir}."
                 echo "Possibly MacOS has changed things (again)."
-                exit 1 
-            else 
+                exit 1
+            else
                 pushd "${XCode_sdk_dir}" > /dev/null
                     echo "Linking missing MacOSX10.14.sdk to MacOSX.sdk in ${XCode_sdk_dir}/"
-                    sudo ln -s "MacOSX.sdk" "MacOSX10.14.sdk" 
+                    sudo ln -s "MacOSX.sdk" "MacOSX10.14.sdk"
                     if [[ $? -ne 0 ]]; then exit 1; fi;
                 popd > /dev/null
-            fi 
-        fi 
-    fi 
-  
+            fi
+        fi
+    fi
+
     echo "Found XCode developer kit."
     echo "Checking for MacPorts or Homebrew package managers."
-  
+
     if [ -x "$(command -v port)" ]; then
         echo "'port' executable detected, assuming that MacPorts"\
         "(https://www.macports.org) is installed and is the package manager."
-    
+
         echo "Installing ToMCAT dependencies using MacPorts."
-    
+
         sudo port selfupdate
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
-        sudo port install \
+        sudo port -N install \
             cmake \
             libfmt \
             doxygen \
@@ -54,13 +66,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
             portaudio
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
-        sudo port install boost -no_static
+        sudo port -N install boost -no_static
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
     elif [ -x "$(command -v brew)" ]; then
         echo "\'brew\' executable detected, assuming that Homebrew"\
         "\(https://brew.sh\) is installed and is the package manager."
-    
+
         echo "Installing ToMCAT dependencies using Homebrew."
 
         brew update
@@ -68,6 +80,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
         # We do not check exit codes for Homebrew installs since `brew install`
         # can return an exit code of 1 when a package is already installed (!!)
+
+        brew tap AdoptOpenJDK/openjdk
+        brew cask install adoptopenjdk8
 
         brew install \
           cmake \
@@ -78,38 +93,19 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
           openblas \
           boost \
           libsndfile \
-          portaudio
+          portaudio \
+          gradle
 
         if [[ ! -z $TRAVIS ]]; then
-          # The Homebrew install of DLib on Travis doesn't play well with CMake
-          # for some reason, so we install DLib on Travis from source rather than
-          # with the Homebrew package manager.
-          pushd "${TOMCAT}/external"
-            # We download a specific commit snapshot of dlib from Github that
-            # contains a fix for the latest version of OpenCV that is being
-            # installed by Homebrew.
-            commit_sha=471c3d30e181a40942177a4358aa0496273d2108
-            curl -L https://github.com/davisking/dlib/archive/${commit_sha}.zip -o dlib.zip
-            unzip dlib.zip
-            mv dlib-${commit_sha} dlib
-          popd
-
           # On Travis, we will install lcov to provide code coverage estimates.
-          brew install lcov
-        else
-          brew install dlib
+          brew install lcov;
         fi;
-
-        # Installing Java
-        brew tap adoptopenjdk/openjdk
-        brew cask install adoptopenjdk8
-        brew install gradle
-
-    else 
+        download_and_extract_dlib
+    else
         echo "No package manager found for $OSTYPE"
-        exit 1 
+        exit 1
     fi
-  
+
 elif [ -x "$(command -v apt-get)" ]; then
     echo "apt-get executable found. Assuming that you are using a flavor of"\
     "Debian Linux, such as Ubuntu."
@@ -123,36 +119,50 @@ elif [ -x "$(command -v apt-get)" ]; then
     # Install a version of CMake more up-to-date than what is available by
     # default for Ubuntu Bionic
 
-    if [[ ! -z $TRAVIS ]]; then
-      sudo apt purge --auto-remove cmake
-      version=3.16
-      build=2
-      mkdir -p ~/temp
-        pushd ~/temp
-          wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
-          tar -xzvf cmake-$version.$build.tar.gz
-          cd cmake-$version.$build/
-          ./bootstrap
-          make -j
-          sudo make install
-        popd
+    if [ -x "$(command -v cmake)" ]; then
+      cmake_version=`cmake --version | head -n 1 | cut -d ' ' -f 3`
+      cmake_major_version=`$cmake_version | cut -d '.' -f 1`
+      cmake_minor_version=`$cmake_version | cut -d '.' -f 2`
+      echo $cmake_version $cmake_major_version $cmake_minor_version
+      if (( $cmake_major_version < 3 )) || (( $cmake_minor_version < 15 )); then
+        ./tools/install_cmake_from_source.sh
+      fi
+    else
+      ./tools/install_cmake_from_source.sh
     fi
 
-    sudo apt-get install \
+    sudo apt-get install -y \
         gcc-9 \
         libfmt-dev \
         doxygen \
         ffmpeg \
         libopenblas-dev \
-        libopencv-dev \
-        libdlib-dev \
         openjdk-8-jdk \
         portaudio19-dev \
         libsndfile1-dev
     if [[ $? -ne 0 ]]; then exit 1; fi;
-else 
+
+    boost_version_header="/usr/local/include/boost/version.hpp"
+    if [[ -f $boost_version_header ]]; then
+      boost_version=`cat $boost_version_header | grep "define BOOST_VERSION " | cut -d' ' -f3`
+      if (( $boost_version < 106900 )); then
+        ./tools/install_boost_from_source.sh
+      fi
+    else
+      ./tools/install_boost_from_source.sh
+    fi
+
+    if [[ ! -f "usr/local/lib/libdlib.a" ]]; then
+      ./tools/install_dlib_from_source.sh
+    fi
+    
+    if [[ ! -d "/usr/local/include/opencv4" ]]; then
+      ./tools/install_opencv_from_source.sh
+    fi
+
+else
     echo "This is not a Mac and not Ubuntu (at least apt-get is not around). We cannot proceed."
-    exit 1 
+    exit 1
 fi
 
 echo "ToMCAT dependency installation complete."

--- a/tools/install_dlib_from_source.sh
+++ b/tools/install_dlib_from_source.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Install DLib from source
+
+# We download a specific commit snapshot of dlib from Github that
+# contains a fix for the latest version of OpenCV that is being
+# installed by Homebrew.
+commit_sha=471c3d30e181a40942177a4358aa0496273d2108
+curl -L https://github.com/davisking/dlib/archive/${commit_sha}.zip -o dlib.zip
+unzip -qq dlib.zip
+mv dlib-${commit_sha} dlib
+pushd dlib
+  mkdir build
+  pushd build
+    cmake ..
+    cmake --build . --config Release
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+    make -j8
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+    sudo make install
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+  popd
+popd

--- a/tools/install_opencv_from_source.sh
+++ b/tools/install_opencv_from_source.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Install OpenCV 4 from source
+
+opencv_version=4.2.0
+wget https://github.com/opencv/opencv/archive/$opencv_version.tar.gz && \
+if [[ $? -ne 0 ]]; then exit 1; fi;
+tar xfz $opencv_version.tar.gz
+if [[ $? -ne 0 ]]; then exit 1; fi;
+
+pushd opencv-$opencv_version
+  mkdir build
+  pushd build
+    cmake -D CMAKE_BUILD_TYPE=RELEASE -D OPENCV_GENERATE_PKGCONFIG=ON ..
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+    make -j8
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+    sudo make install
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+    pkg-config --modversion opencv4
+    if [[ $? -ne 0 ]]; then exit 1; fi;
+  popd
+popd


### PR DESCRIPTION
This PR refactors the installations scripts for greater modularity and creating a Docker image based on Ubuntu Bionic.

New scripts: `tools/install_<cmake/boost/opencv/dlib>_from_source.sh`

The scripts also now specify a particular commit of Dlib to download and install, since the latest release of Dlib (19.19) does not work with OpenCV 4.2.0 and OpenCV 3.4.9.

Extracting files from .tgz and .zip files is now quieter.