### PR TITLE
Constrain Player

### DIFF
--- a/src/Mission.cpp
+++ b/src/Mission.cpp
@@ -117,7 +117,7 @@ namespace tomcat {
                 />
               </ServerHandlers>
           </ServerSection>
-          <AgentSection mode="Survival">
+          <AgentSection mode="Adventure">
               <Name>Tomcat</Name>
               <AgentStart>
               </AgentStart>


### PR DESCRIPTION
This PR limits the kind of interactions a player can have with their environment by setting the default game-mode to "Adventure" in Mission.cpp.

The player will not be able to break anything with hands or any tools (except specially tagged tools, but that is not included in this PR because the player isn't using tools to break anything in our missions yet.)

The player can still craft, pick up items, click buttons and levers and hit entities. This also means that given a weapon, the player can hit entities with it.