### PR TITLE
Fixing issue with the mouse

### DIFF
--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
@@ -127,8 +127,9 @@ public class MalmoModClient {
 		this.originalMouseHelper = Minecraft.getMinecraft().mouseHelper;
 		this.mouseHook = new MouseHook();
 		this.mouseHook.isOverriding = true;
-		Minecraft.getMinecraft().mouseHelper = this.mouseHook;
-		setInputType(InputType.AI);
+		// We don't need to temper with the mouse 
+		//Minecraft.getMinecraft().mouseHelper = this.mouseHook;
+		//setInputType(InputType.AI);
 	}
 
 	/**

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/gui/GUIScreenUndismissableOnEscapeKey.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/gui/GUIScreenUndismissableOnEscapeKey.java
@@ -2,9 +2,17 @@ package edu.arizona.tomcat.Mission.gui;
 
 import java.io.IOException;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 
 public class GUIScreenUndismissableOnEscapeKey extends GuiScreen {
+	
+	@Override
+	public void initGui() {
+		super.initGui();
+		// Show mouse cursor so that the player can click on a button
+		Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
+	}
 	
 	@Override
 	protected void keyTyped(char typedChar, int keyCode) throws IOException {

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/gui/MessageScreen.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/gui/MessageScreen.java
@@ -23,6 +23,7 @@ public class MessageScreen extends GUIScreenUndismissableOnEscapeKey {
 		
 	@Override
 	public void initGui() {
+		super.initGui();
 		this.addMessageToTheScreen();
 	}
 	


### PR DESCRIPTION
Issue with the mouse cursor was fixed. I am asking Minecraft to ungrab the mouse when a screen prompts. Now we don't need to use malmo mouse behaviour anymore and we can still have the cursor shown on the screen so that the player can press a button.