### PR TITLE
FFmpeg integration, data collection streamlining, script refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
 # Build directory for CMake
 
 build
-
-# Automatically generated files and directories from example.cpp mission
-mission_records
-*.tgz
-
 *.swp
 
 # IDEs
@@ -79,3 +74,6 @@ data/*
 *.tar.gz
 *.tgz
 *.zip
+
+# Temporary directory for ToMCAT-generated files.
+tmp

--- a/external/malmo/Malmo/src/AgentHost.cpp
+++ b/external/malmo/Malmo/src/AgentHost.cpp
@@ -306,7 +306,7 @@ namespace malmo {
     // Video producing handlers.
     if (mission.isVideoRequested(this->current_role)) {
       this->video_server =
-          listenForVideo(this->video_server,
+          this->listenForVideo(this->video_server,
                          this->current_mission_init->getAgentVideoPort(),
                          mission.getVideoWidth(this->current_role),
                          mission.getVideoHeight(this->current_role),
@@ -315,7 +315,7 @@ namespace malmo {
     }
     if (mission.isDepthRequested(this->current_role)) {
       this->depth_server =
-          listenForVideo(this->depth_server,
+          this->listenForVideo(this->depth_server,
                          this->current_mission_init->getAgentDepthPort(),
                          mission.getVideoWidth(this->current_role),
                          mission.getVideoHeight(this->current_role),
@@ -324,7 +324,7 @@ namespace malmo {
     }
     if (mission.isLuminanceRequested(this->current_role)) {
       this->luminance_server =
-          listenForVideo(this->luminance_server,
+          this->listenForVideo(this->luminance_server,
                          this->current_mission_init->getAgentLuminancePort(),
                          mission.getVideoWidth(this->current_role),
                          mission.getVideoHeight(this->current_role),
@@ -333,7 +333,7 @@ namespace malmo {
     }
     if (mission.isColourMapRequested(this->current_role)) {
       this->colourmap_server =
-          listenForVideo(this->colourmap_server,
+          this->listenForVideo(this->colourmap_server,
                          this->current_mission_init->getAgentColourMapPort(),
                          mission.getVideoWidth(this->current_role),
                          mission.getVideoHeight(this->current_role),

--- a/external/malmo/Malmo/src/AgentHost.cpp
+++ b/external/malmo/Malmo/src/AgentHost.cpp
@@ -301,7 +301,7 @@ namespace malmo {
         boost::make_shared<MissionRecord>(mission_record);
     this->current_role = role;
 
-    listenForMissionControlMessages(
+    this->listenForMissionControlMessages(
         this->current_mission_init->getAgentMissionControlPort());
     // Video producing handlers.
     if (mission.isVideoRequested(this->current_role)) {
@@ -340,8 +340,8 @@ namespace malmo {
                          3,
                          TimestampedVideoFrame::COLOUR_MAP);
     }
-    listenForRewards(this->current_mission_init->getAgentRewardsPort());
-    listenForObservations(
+    this->listenForRewards(this->current_mission_init->getAgentRewardsPort());
+    this->listenForObservations(
         this->current_mission_init->getAgentObservationsPort());
 
     if (this->commands_stream.is_open()) {

--- a/external/malmo/Malmo/src/BmpFrameWriter.cpp
+++ b/external/malmo/Malmo/src/BmpFrameWriter.cpp
@@ -1,347 +1,419 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
 #include "BmpFrameWriter.h"
-#include "Tarball.hpp"
 #include "Logger.h"
+#include "Tarball.hpp"
 
 // STL:
 #include <exception>
 #include <sstream>
 #include <stdio.h>
 
+#include <boost/asio.hpp> // For htonl
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/asio.hpp>   // For htonl
 #include <boost/make_shared.hpp>
 
 #define LOG_COMPONENT Logger::LOG_VIDEO
 
-namespace malmo
-{
-    class TarHelper
-    {
-    public:
-        TarHelper(boost::filesystem::path path, bool numpy_format, std::size_t max_tar_size = 1 << 30) : path(path), frame_count(0), max_tar_size(max_tar_size), unzipped_byte_count(0), compression_level(6)
+using namespace std;
+namespace fs = boost::filesystem;
+
+namespace malmo {
+  class TarHelper {
+  public:
+    TarHelper(fs::path path, bool numpy_format, size_t max_tar_size = 1 << 30)
+        : path(path), frame_count(0), max_tar_size(max_tar_size),
+          unzipped_byte_count(0), compression_level(6) {
+      // For now, get this from the environment:
+      char* compression_env = getenv("MALMO_BMP_COMPRESSION_LEVEL");
+      if (compression_env) {
+        this->compression_level = min(max(atoi(compression_env), 0), 9);
+      }
+      // Are big-endian or little-endian?
+      // Simple way to check using htonl (always converts to big-endian)
+      this->bigendian = (htonl(1) == 1);
+      this->numpy_format = numpy_format;
+    }
+
+    ~TarHelper() {
+      if (this->tarball)
+        this->tarball->finish();
+      if (this->filter)
+        this->filter->pop();
+    }
+
+    void addFrame(const TimestampedVideoFrame& frame) {
+      if (!this->tarball ||
+          frame.pixels.size() + this->unzipped_byte_count > this->max_tar_size)
+        reset();
+
+      stringstream frame_name;
+      // For 1bpp, save as portable greyscale (pgm)
+      // For 3bpp, save as ppm.
+      // For 4bpp, save as numpy array if this->numpy_format is true.
+      // Otherwise, strip out the alpha channel and save as two files - a pgm
+      // and a pbm. Note - these are horribly inefficient file formats, but
+      // speed of writing is paramount - there's no time to do png compression,
+      // etc. We just dump the frames to the disk as fast as possible, in a
+      // format that is relatively easy to open.
+      string extension = (frame.channels == 1)
+                             ? ".pgm"
+                             : ((this->numpy_format) ? ".npy" : ".ppm");
+      frame_name << "frame_" << setfill('0') << setw(6) << this->frame_count
+                 << extension;
+
+      stringstream frame_header;
+      if (frame.channels != 4) {
+        string magic_number = (frame.channels == 1) ? "P5" : "P6";
+        frame_header << magic_number << "\n"
+                     << frame.width << " " << frame.height << "\n255\n";
+        string header = frame_header.str();
+        this->tarball->putMemWithHeader(
+            header.c_str(),
+            header.length(),
+            reinterpret_cast<const char*>(&(frame.pixels[0])),
+            frame.pixels.size(),
+            frame_name.str().c_str());
+        this->unzipped_byte_count += header.length() + frame.pixels.size();
+      }
+      else if (this->numpy_format) {
+        // Save in numpy format, for ease of use with Python.
+        // See here https://docs.scipy.org/doc/numpy/neps/npy-format.html for
+        // the specification. There are essentially two parts - the header and
+        // the data. The header must be padded such that the data begins on a 16
+        // byte boundary. The header is made up of a ten byte "preamble"
+        // followed by a literal string description of a python dictionary. This
+        // dictionary contains everything numpy needs to know in order to read
+        // the data. The preamble contains everything numpy needs to know in
+        // order to read the header.
+
+        // Note that, in addFrame's typical use, each frame we are called with
+        // will have the same dimensions, so this header will not change from
+        // call to call - it could be created ahead of time and reused for each
+        // frame.
+
+        // First 8 bytes: magic number (0x93), the string "NUMPY", and the major
+        // and minor file format versions.
+        frame_header << (char)0x93 << "NUMPY" << (char)0x01 << (char)0x00;
+
+        // Construct the ASCII description of a python dictionary containing the
+        // details of this file. (Shape is rows x cols, so height x width.)
+        stringstream pydict;
+        pydict << "{'descr': '" << (this->bigendian ? ">" : "<")
+               << "f4', 'fortran_order':False, 'shape':(" << frame.height << ","
+               << frame.width << ") }";
+
+        // The dictionary must be terminated with a newline character, but the
+        // padding is added before that, as spaces.
+        uint16_t minimum_header_length =
+            (uint16_t)(pydict.str().length()) +
+            11; // +1 for the newline terminator, +10 for the preamble.
+        // Work out the padded length:
+        uint16_t padded_header_length =
+            16 * int(ceil(minimum_header_length / 16.0));
+        if (padded_header_length != minimum_header_length)
+          pydict << string("                ")
+                        .substr(0,
+                                padded_header_length - minimum_header_length);
+        pydict << "\n";
+        // The length of the dictionary definition is encoded in the preamble
+        // (not the length of the *whole* header - ie subtract the premable
+        // size.)
+        uint16_t header_length = padded_header_length - 10;
+        // It must be stored in little-endian format:
+        unsigned char lsb = header_length & 0xff;
+        unsigned char msb = header_length >> 8;
+        frame_header << lsb << msb;
+        // Preamble is complete - now write out the dictionary:
+        frame_header << pydict.str();
+        string header = frame_header.str();
+        // Now store the data, with this header:
+        this->tarball->putMemWithHeader(
+            header.c_str(),
+            header.length(),
+            reinterpret_cast<const char*>(&(frame.pixels[0])),
+            frame.pixels.size(),
+            frame_name.str().c_str());
+        this->unzipped_byte_count += header.length() + frame.pixels.size();
+      }
+      else {
+        // We get here if the user has requested the combined video/depthmap
+        // data - eg the depthmap is encoded in the alpha channel. The ppm
+        // format doesn't support 32bpp RGBA data - and, arguably, it makes no
+        // sense to interpret the depth values as a alpha values anyway, so we
+        // split the data into a 24bpp RGB image and an 8bpp greyscale image.
+
+        // Rearrange RGBARGBA into RGBRGB...AA
+        char* out_pixels = new char[frame.width * frame.height * 4];
+        int offset_rgb = 0;
+        int offset_a = frame.width * frame.height * 3;
+        for (int i = 0; i < frame.width * frame.height; i++) {
+          out_pixels[offset_rgb] = frame.pixels[i * 4];
+          out_pixels[offset_rgb + 1] = frame.pixels[i * 4 + 1];
+          out_pixels[offset_rgb + 2] = frame.pixels[i * 4 + 2];
+          out_pixels[offset_a] = frame.pixels[i * 4 + 3]; // copy alpha value
+          offset_rgb += 3;
+          offset_a += 1;
+        }
+
+        // Save alpha channel:
+        stringstream alpha_frame_name;
+        alpha_frame_name << "frame_" << setfill('0') << setw(6)
+                         << this->frame_count << ".pgm";
+        stringstream alpha_frame_header;
+        alpha_frame_header << "P5"
+                           << "\n"
+                           << frame.width << " " << frame.height << "\n255\n";
+        string header = alpha_frame_header.str();
+        this->tarball->putMemWithHeader(
+            header.c_str(),
+            header.length(),
+            reinterpret_cast<const char*>(
+                &(out_pixels[frame.width * frame.height * 3])),
+            frame.width * frame.height,
+            alpha_frame_name.str().c_str());
+
+        // Save RGB:
+        stringstream rgb_frame_name;
+        rgb_frame_name << "frame_" << setfill('0') << setw(6)
+                       << this->frame_count << ".ppm";
+        stringstream rgb_frame_header;
+        rgb_frame_header << "P6"
+                         << "\n"
+                         << frame.width << " " << frame.height << "\n255\n";
+        header = rgb_frame_header.str();
+        this->tarball->putMemWithHeader(
+            header.c_str(),
+            header.length(),
+            reinterpret_cast<const char*>(&(out_pixels[0])),
+            frame.width * frame.height * 3,
+            rgb_frame_name.str().c_str());
+        this->unzipped_byte_count += 2 * header.length() + frame.pixels.size();
+        delete[] out_pixels;
+      }
+      this->frame_count++;
+    }
+
+    int getFrameCount() const { return this->frame_count; }
+
+  private:
+    void reset() {
+      if (this->tarball)
+        this->tarball->finish();
+      if (this->filter)
+        this->filter->pop();
+      stringstream tarname;
+      tarname << "bmps_" << setfill('0') << setw(6) << this->frame_count
+              << ".tar.gz";
+      fs::path tarpath = this->path / tarname.str();
+      this->backing_file =
+          boost::make_shared<ofstream>(tarpath.string(), fstream::binary);
+      this->filter = boost::make_shared<boost::iostreams::filtering_ostream>();
+      boost::iostreams::gzip_params params;
+      params.level = this->compression_level;
+      this->filter->push(boost::iostreams::gzip_compressor(params));
+      this->filter->push(*(this->backing_file));
+      this->tarball = boost::make_shared<lindenb::io::Tar>(*(this->filter));
+      this->unzipped_byte_count = 0;
+      LOGFINE(tarname.str(), LT(" created."));
+    }
+
+    int frame_count;
+    int compression_level; // gzip compression level - 1=best speed, 9=best
+                           // compression (6 is currently default according to
+                           // zlib docs)
+    bool bigendian;
+    bool numpy_format;
+    size_t max_tar_size;
+    size_t unzipped_byte_count;
+    fs::path path;
+    boost::shared_ptr<lindenb::io::Tar> tarball;
+    boost::shared_ptr<boost::iostreams::filtering_ostream> filter;
+    boost::shared_ptr<ofstream> backing_file;
+  };
+
+  BmpFrameWriter::BmpFrameWriter(string path,
+                                 string frame_info_filename,
+                                 bool saveInNumpyFormat)
+      : path(path), is_open(false), is_numpy_format(saveInNumpyFormat) {
+    fs::path fs_path(path);
+    if (!fs::exists(fs_path)) {
+      fs::create_directories(fs_path);
+    }
+    this->frame_info_path = fs_path / frame_info_filename;
+    this->frames_path = fs_path / string("bmps.tar");
+  }
+
+  BmpFrameWriter::~BmpFrameWriter() { this->close(); }
+
+  void BmpFrameWriter::open() {
+    this->close();
+
+    this->frame_info_stream.open(this->frame_info_path.string());
+
+    this->is_open = true;
+
+    this->start_time = boost::posix_time::microsec_clock::universal_time();
+    this->last_timestamp = this->start_time - this->frame_duration;
+
+    this->frame_index = 0;
+
+    this->frames_available = false;
+    this->frame_writer_thread =
+        boost::thread(&BmpFrameWriter::writeFrames, this);
+  }
+
+  bool BmpFrameWriter::isOpen() const { return this->is_open; }
+
+  void BmpFrameWriter::close() {
+    LOGSECTION(LOG_FINE, "In BmpFrameWriter::close()...");
+
+    if (this->is_open) {
+      this->is_open = false;
+      {
+        boost::lock_guard<boost::mutex> frames_available_guard(
+            this->frames_available_mutex);
+
+        this->frames_available = true;
+      }
+
+      LOGFINE(LT("Notifying worker thread that frames are available, in order "
+                 "to close."));
+      this->frames_available_cond.notify_one();
+      LOGFINE(LT("Waiting for worker thread to join."));
+      this->frame_writer_thread.join();
+      this->frame_info_stream.close();
+      LOGFINE(LT("Worker thread joined."));
+      LOGFINE(LT("Frames received for writing: "), this->frame_index);
+      LOGFINE(LT("Frames actually written: "), this->frames_actually_written);
+    }
+  }
+
+  void BmpFrameWriter::writeFrames() {
+    this->frames_actually_written = 0;
+    TarHelper tarrer(fs::path(this->path), this->is_numpy_format);
+    while (this->is_open) {
+      // Wait for frames to become available
+      {
+        boost::unique_lock<boost::mutex> lock(this->frames_available_mutex);
+        while (!this->frames_available) {
+          this->frames_available_cond.wait(lock);
+        }
+      }
+      while (true) {
+        TimestampedVideoFrame frame;
         {
-            // For now, get this from the environment:
-            char *compression_env = getenv("MALMO_BMP_COMPRESSION_LEVEL");
-            if (compression_env) {
-                this->compression_level = std::min(std::max(atoi(compression_env), 0), 9);
-            }
-            // Are big-endian or little-endian?
-            // Simple way to check using htonl (always converts to big-endian)
-            this->bigendian = (htonl(1) == 1);
-            this->numpy_format = numpy_format;
+          boost::lock_guard<boost::mutex> buffer_guard(
+              this->frame_buffer_mutex);
+
+          if (this->frame_buffer.size() > 0) {
+            frame = this->frame_buffer.front();
+            this->frame_buffer.pop();
+          }
+          else {
+            boost::lock_guard<boost::mutex> frames_available_guard(
+                this->frames_available_mutex);
+            this->frames_available = false;
+            break;
+          }
         }
+        // Write frame into tarball:
+        LOGTRACE(LT("Tarring frame "),
+                 tarrer.getFrameCount() + 1,
+                 LT(", "),
+                 frame.width,
+                 LT("x"),
+                 frame.height,
+                 LT("x"),
+                 frame.channels);
+        tarrer.addFrame(frame);
+        // And add details to index files:
+        stringstream name;
+        name << "frame_" << setfill('0') << setw(6) << tarrer.getFrameCount();
+        stringstream posdata;
+        posdata << "xyzyp: " << frame.xPos << " " << frame.yPos << " "
+                << frame.zPos << " " << frame.yaw << " " << frame.pitch;
+        this->frame_info_stream
+            << boost::posix_time::to_iso_string(frame.timestamp) << " "
+            << name.str() << " " << posdata.str() << endl;
+        this->frames_actually_written++;
+      }
+    }
+    LOGTRACE(LT("Flushing frame info stream"));
+    this->frame_info_stream
+        << "# EOF - frames written: " << this->frames_actually_written << endl;
+    this->frame_info_stream.flush();
+  }
 
-        ~TarHelper()
-        {
-            if (this->tarball)
-                this->tarball->finish();
-            if (this->filter)
-                this->filter->pop();
-        }
-
-        void addFrame(const TimestampedVideoFrame& frame)
-        {
-            if (!this->tarball || frame.pixels.size() + this->unzipped_byte_count > this->max_tar_size)
-                reset();
-
-            std::stringstream frame_name;
-            // For 1bpp, save as portable greyscale (pgm)
-            // For 3bpp, save as ppm.
-            // For 4bpp, save as numpy array if this->numpy_format is true.
-            // Otherwise, strip out the alpha channel and save as two files - a pgm and a pbm.
-            // Note - these are horribly inefficient file formats, but speed of writing is paramount - there's no time to do png compression, etc.
-            // We just dump the frames to the disk as fast as possible, in a format that is relatively easy to open.
-            std::string extension = (frame.channels == 1) ? ".pgm" : ((this->numpy_format) ? ".npy" : ".ppm");
-            frame_name << "frame_" << std::setfill('0') << std::setw(6) << this->frame_count << extension;
-
-            std::stringstream frame_header;
-            if (frame.channels != 4 )
-            {
-                std::string magic_number = (frame.channels == 1) ? "P5" : "P6";
-                frame_header << magic_number << "\n" << frame.width << " " << frame.height << "\n255\n";
-                std::string header = frame_header.str();
-                this->tarball->putMemWithHeader(header.c_str(), header.length(), reinterpret_cast<const char*>(&(frame.pixels[0])), frame.pixels.size(), frame_name.str().c_str());
-                this->unzipped_byte_count += header.length() + frame.pixels.size();
-            }
-            else if (this->numpy_format)
-            {
-                // Save in numpy format, for ease of use with Python.
-                // See here https://docs.scipy.org/doc/numpy/neps/npy-format.html for the specification.
-                // There are essentially two parts - the header and the data. The header must be padded such that the data
-                // begins on a 16 byte boundary.
-                // The header is made up of a ten byte "preamble" followed by a literal string description of a python dictionary.
-                // This dictionary contains everything numpy needs to know in order to read the data. The preamble contains everything numpy
-                // needs to know in order to read the header.
-
-                // Note that, in addFrame's typical use, each frame we are called with will have the same dimensions, so this header will not change
-                // from call to call - it could be created ahead of time and reused for each frame.
-
-                // First 8 bytes: magic number (0x93), the string "NUMPY", and the major and minor file format versions.
-                frame_header << (char)0x93 << "NUMPY" << (char)0x01 << (char)0x00;
-
-                // Construct the ASCII description of a python dictionary containing the details of this file. (Shape is rows x cols, so height x width.)
-                std::stringstream pydict;
-                pydict << "{'descr': '" << (this->bigendian ? ">" : "<") << "f4', 'fortran_order':False, 'shape':(" << frame.height << "," << frame.width << ") }";
-
-                // The dictionary must be terminated with a newline character, but the padding is added before that, as spaces.
-                uint16_t minimum_header_length = (uint16_t)(pydict.str().length()) + 11; // +1 for the newline terminator, +10 for the preamble.
-                // Work out the padded length:
-                uint16_t padded_header_length = 16 * int(ceil(minimum_header_length / 16.0));
-                if (padded_header_length != minimum_header_length)
-                    pydict << std::string("                ").substr(0, padded_header_length - minimum_header_length);
-                pydict << "\n";
-                // The length of the dictionary definition is encoded in the preamble (not the length of the *whole* header - ie subtract the premable size.)
-                uint16_t header_length = padded_header_length - 10;
-                // It must be stored in little-endian format:
-                unsigned char lsb = header_length & 0xff;
-                unsigned char msb = header_length >> 8;
-                frame_header << lsb << msb;
-                // Preamble is complete - now write out the dictionary:
-                frame_header << pydict.str();
-                std::string header = frame_header.str();
-                // Now store the data, with this header:
-                this->tarball->putMemWithHeader(header.c_str(), header.length(), reinterpret_cast<const char*>(&(frame.pixels[0])), frame.pixels.size(), frame_name.str().c_str());
-                this->unzipped_byte_count += header.length() + frame.pixels.size();
-            }
-            else
-            {
-                // We get here if the user has requested the combined video/depthmap data - eg the depthmap is encoded in the alpha channel.
-                // The ppm format doesn't support 32bpp RGBA data - and, arguably, it makes no sense to interpret the depth values as a alpha values
-                // anyway, so we split the data into a 24bpp RGB image and an 8bpp greyscale image.
-
-                // Rearrange RGBARGBA into RGBRGB...AA
-                char *out_pixels = new char[frame.width * frame.height * 4];
-                int offset_rgb = 0;
-                int offset_a = frame.width * frame.height * 3;
-                for (int i = 0; i < frame.width*frame.height; i++)
-                {
-                    out_pixels[offset_rgb] = frame.pixels[i * 4];
-                    out_pixels[offset_rgb + 1] = frame.pixels[i * 4 + 1];
-                    out_pixels[offset_rgb + 2] = frame.pixels[i * 4 + 2];
-                    out_pixels[offset_a] = frame.pixels[i * 4 + 3];   // copy alpha value
-                    offset_rgb += 3;
-                    offset_a += 1;
-                }
-
-                // Save alpha channel:
-                std::stringstream alpha_frame_name;
-                alpha_frame_name << "frame_" << std::setfill('0') << std::setw(6) << this->frame_count << ".pgm";
-                std::stringstream alpha_frame_header;
-                alpha_frame_header << "P5" << "\n" << frame.width << " " << frame.height << "\n255\n";
-                std::string header = alpha_frame_header.str();
-                this->tarball->putMemWithHeader(header.c_str(), header.length(), reinterpret_cast<const char*>(&(out_pixels[frame.width * frame.height * 3])), frame.width * frame.height, alpha_frame_name.str().c_str());
-
-                // Save RGB:
-                std::stringstream rgb_frame_name;
-                rgb_frame_name << "frame_" << std::setfill('0') << std::setw(6) << this->frame_count << ".ppm";
-                std::stringstream rgb_frame_header;
-                rgb_frame_header << "P6" << "\n" << frame.width << " " << frame.height << "\n255\n";
-                header = rgb_frame_header.str();
-                this->tarball->putMemWithHeader(header.c_str(), header.length(), reinterpret_cast<const char*>(&(out_pixels[0])), frame.width * frame.height * 3, rgb_frame_name.str().c_str());
-                this->unzipped_byte_count += 2 * header.length() + frame.pixels.size();
-                delete[] out_pixels;
-            }
-            this->frame_count++;
-        }
-
-        int getFrameCount() const { return this->frame_count; }
-
-    private:
-        void reset()
-        {
-            if (this->tarball)
-                this->tarball->finish();
-            if (this->filter)
-                this->filter->pop();
-            std::stringstream tarname;
-            tarname << "bmps_" << std::setfill('0') << std::setw(6) << this->frame_count << ".tar.gz";
-            boost::filesystem::path tarpath = this->path / tarname.str();
-            this->backing_file = boost::make_shared<std::ofstream>(tarpath.string(), std::fstream::binary);
-            this->filter = boost::make_shared<boost::iostreams::filtering_ostream>();
-            boost::iostreams::gzip_params params;
-            params.level = this->compression_level;
-            this->filter->push(boost::iostreams::gzip_compressor(params));
-            this->filter->push(*(this->backing_file));
-            this->tarball = boost::make_shared<lindenb::io::Tar>(*(this->filter));
-            this->unzipped_byte_count = 0;
-            LOGFINE(tarname.str(), LT(" created."));
-        }
-
-        int frame_count;
-        int compression_level;  // gzip compression level - 1=best speed, 9=best compression (6 is currently default according to zlib docs)
-        bool bigendian;
-        bool numpy_format;
-        std::size_t max_tar_size;
-        std::size_t unzipped_byte_count;
-        boost::filesystem::path path;
-        boost::shared_ptr<lindenb::io::Tar> tarball;
-        boost::shared_ptr<boost::iostreams::filtering_ostream> filter;
-        boost::shared_ptr<std::ofstream> backing_file;
-    };
-
-    BmpFrameWriter::BmpFrameWriter(std::string path, std::string frame_info_filename, bool saveInNumpyFormat)
-        : path(path)
-        , is_open(false)
-        , is_numpy_format(saveInNumpyFormat)
+  bool BmpFrameWriter::write(TimestampedVideoFrame frame) {
+    this->last_timestamp = frame.timestamp;
+    bool addedFrame = false;
     {
-        boost::filesystem::path fs_path(path);
-        if (!boost::filesystem::exists(fs_path)) {
-            boost::filesystem::create_directories(fs_path);
-        }
-        this->frame_info_path = fs_path / frame_info_filename;
-        this->frames_path = fs_path / std::string("bmps.tar");
+      boost::lock_guard<boost::mutex> buffer_guard(this->frame_buffer_mutex);
+      // Drop the frame if our buffer has reached a certain size.
+      if (this->frame_buffer.size() < 300) {
+        LOGTRACE(LT("Pushing frame "),
+                 this->frame_index,
+                 LT(", "),
+                 frame.width,
+                 LT("x"),
+                 frame.height,
+                 LT("x"),
+                 frame.channels,
+                 LT(" to write buffer."));
+        this->frame_buffer.push(frame);
+        this->frame_index++;
+        addedFrame = true;
+      }
+      else {
+        LOGWARNING(LT("BmpFrameWriter dropping frame - buffer is full - try "
+                      "reducing MALMO_BMP_COMPRESSION_LEVEL (1=best speed, "
+                      "9=best compression, 6=default)"));
+      }
     }
 
-    BmpFrameWriter::~BmpFrameWriter()
-    {
-        this->close();
+    if (addedFrame) {
+      {
+        boost::lock_guard<boost::mutex> frames_available_guard(
+            this->frames_available_mutex);
+        this->frames_available = true;
+      }
+
+      this->frames_available_cond.notify_one();
     }
+    return addedFrame;
+  }
 
-    void BmpFrameWriter::open()
-    {
-        this->close();
-
-        this->frame_info_stream.open(this->frame_info_path.string());
-
-        this->is_open = true;
-
-        this->start_time = boost::posix_time::microsec_clock::universal_time();
-        this->last_timestamp = this->start_time - this->frame_duration;
-
-        this->frame_index = 0;
-
-        this->frames_available = false;
-        this->frame_writer_thread = boost::thread(&BmpFrameWriter::writeFrames, this);
-    }
-
-    bool BmpFrameWriter::isOpen() const
-    {
-        return this->is_open;
-    }
-
-    void BmpFrameWriter::close()
-    {
-        LOGSECTION(LOG_FINE, "In BmpFrameWriter::close()...");
-
-        if (this->is_open) {
-            this->is_open = false;
-            {
-                boost::lock_guard<boost::mutex> frames_available_guard(this->frames_available_mutex);
-
-                this->frames_available = true;
-            }
-
-            LOGFINE(LT("Notifying worker thread that frames are available, in order to close."));
-            this->frames_available_cond.notify_one();
-            LOGFINE(LT("Waiting for worker thread to join."));
-            this->frame_writer_thread.join();
-            this->frame_info_stream.close();
-            LOGFINE(LT("Worker thread joined."));
-            LOGFINE(LT("Frames received for writing: "), this->frame_index);
-            LOGFINE(LT("Frames actually written: "), this->frames_actually_written);
-        }
-    }
-
-    void BmpFrameWriter::writeFrames()
-    {
-        this->frames_actually_written = 0;
-        TarHelper tarrer(boost::filesystem::path(this->path), this->is_numpy_format);
-        while (this->is_open) {
-            // Wait for frames to become available
-            {
-                boost::unique_lock<boost::mutex> lock(this->frames_available_mutex);
-                while (!this->frames_available) {
-                    this->frames_available_cond.wait(lock);
-                }
-            }
-            while (true) {
-                TimestampedVideoFrame frame;
-                {
-                    boost::lock_guard<boost::mutex> buffer_guard(this->frame_buffer_mutex);
-
-                    if (this->frame_buffer.size() > 0) {
-                        frame = this->frame_buffer.front();
-                        this->frame_buffer.pop();
-                    }
-                    else {
-                        boost::lock_guard<boost::mutex> frames_available_guard(this->frames_available_mutex);
-                        this->frames_available = false;
-                        break;
-                    }
-                }
-                // Write frame into tarball:
-                LOGTRACE(LT("Tarring frame "), tarrer.getFrameCount() + 1, LT(", "), frame.width, LT("x"), frame.height, LT("x"), frame.channels);
-                tarrer.addFrame(frame);
-                // And add details to index files:
-                std::stringstream name;
-                name << "frame_" << std::setfill('0') << std::setw(6) << tarrer.getFrameCount();
-                std::stringstream posdata;
-                posdata << "xyzyp: " << frame.xPos << " " << frame.yPos << " " << frame.zPos << " " << frame.yaw << " " << frame.pitch;
-                this->frame_info_stream << boost::posix_time::to_iso_string(frame.timestamp) << " " << name.str() << " " << posdata.str() << std::endl;
-                this->frames_actually_written++;
-            }
-        }
-        LOGTRACE(LT("Flushing frame info stream"));
-        this->frame_info_stream << "# EOF - frames written: " << this->frames_actually_written << std::endl;
-        this->frame_info_stream.flush();
-    }
-
-    bool BmpFrameWriter::write(TimestampedVideoFrame frame)
-    {
-        this->last_timestamp = frame.timestamp;
-        bool addedFrame = false;
-        {
-            boost::lock_guard<boost::mutex> buffer_guard(this->frame_buffer_mutex);
-            // Drop the frame if our buffer has reached a certain size.
-            if (this->frame_buffer.size() < 300) {
-                LOGTRACE(LT("Pushing frame "), this->frame_index, LT(", "), frame.width, LT("x"), frame.height, LT("x"), frame.channels, LT(" to write buffer."));
-                this->frame_buffer.push(frame);
-                this->frame_index++;
-                addedFrame = true;
-            }
-            else {
-                LOGWARNING(LT("BmpFrameWriter dropping frame - buffer is full - try reducing MALMO_BMP_COMPRESSION_LEVEL (1=best speed, 9=best compression, 6=default)"));
-            }
-        }
-
-        if (addedFrame) {
-            {
-                boost::lock_guard<boost::mutex> frames_available_guard(this->frames_available_mutex);
-                this->frames_available = true;
-            }
-
-            this->frames_available_cond.notify_one();
-        }
-        return addedFrame;
-    }
-
-    std::unique_ptr<BmpFrameWriter> BmpFrameWriter::create(std::string path, std::string info_filename, bool saveInNumpyFormat)
-    {
-        std::unique_ptr<BmpFrameWriter> instance( new BmpFrameWriter(path, info_filename, saveInNumpyFormat) );
-        return instance;
-    }
-}
+  unique_ptr<BmpFrameWriter> BmpFrameWriter::create(string path,
+                                                    string info_filename,
+                                                    bool saveInNumpyFormat) {
+    unique_ptr<BmpFrameWriter> instance(
+        new BmpFrameWriter(path, info_filename, saveInNumpyFormat));
+    return instance;
+  }
+} // namespace malmo
 
 #undef LOG_COMPONENT

--- a/external/malmo/Malmo/src/BmpFrameWriter.h
+++ b/external/malmo/Malmo/src/BmpFrameWriter.h
@@ -1,24 +1,26 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _BMPFRAMEWRITER_H_
-#define _BMPFRAMEWRITER_H_
+#pragma once
 
 // Local:
 #include "TimestampedVideoFrame.h"
@@ -30,52 +32,55 @@
 #include <boost/thread.hpp>
 
 // STL:
-#include <string>
 #include <fstream>
 #include <iostream>
 #include <queue>
+#include <string>
 
-namespace malmo
-{
-    class BmpFrameWriter : public IFrameWriter
-    {
-    public:
-        BmpFrameWriter(std::string path, std::string frame_info_filename, bool saveInNumpyFormat);
-        virtual ~BmpFrameWriter();
-        virtual void open();
-        virtual void close();
-        
-        virtual bool write(TimestampedVideoFrame frame);
-        virtual bool isOpen() const;
-        virtual size_t getFrameWriteCount() const { return frames_actually_written; }
+namespace malmo {
+  class BmpFrameWriter : public IFrameWriter {
+  public:
+    BmpFrameWriter(std::string path,
+                   std::string frame_info_filename,
+                   bool saveInNumpyFormat);
+    virtual ~BmpFrameWriter();
+    virtual void open();
+    virtual void close();
 
-        static std::unique_ptr<BmpFrameWriter> create(std::string path, std::string frame_info_filename, bool saveInNumpyFormat);
+    virtual bool write(TimestampedVideoFrame frame);
+    virtual bool isOpen() const;
+    virtual size_t getFrameWriteCount() const {
+      return frames_actually_written;
+    }
 
-    protected:
-        std::string path;
-        bool is_open;
-        bool is_numpy_format;
+    static std::unique_ptr<BmpFrameWriter>
+    create(std::string path,
+           std::string frame_info_filename,
+           bool saveInNumpyFormat);
 
-    private:
-        void writeFrames();
+  protected:
+    std::string path;
+    bool is_open;
+    bool is_numpy_format;
 
-        boost::posix_time::ptime start_time;
-        boost::posix_time::ptime last_timestamp;
-        boost::posix_time::time_duration frame_duration;
-        std::ofstream frame_info_stream;
-        boost::filesystem::path frame_info_path;
-        boost::filesystem::path frames_path;
-        int frame_index;
-        int frames_actually_written = 0;
+  private:
+    void writeFrames();
 
-        std::queue<TimestampedVideoFrame> frame_buffer;
-        boost::mutex write_mutex;
-        boost::mutex frame_buffer_mutex;
-        boost::mutex frames_available_mutex;
-        boost::condition_variable frames_available_cond;
-        bool frames_available;
-        boost::thread frame_writer_thread;
-    };
-}
+    boost::posix_time::ptime start_time;
+    boost::posix_time::ptime last_timestamp;
+    boost::posix_time::time_duration frame_duration;
+    std::ofstream frame_info_stream;
+    boost::filesystem::path frame_info_path;
+    boost::filesystem::path frames_path;
+    int frame_index;
+    int frames_actually_written = 0;
 
-#endif
+    std::queue<TimestampedVideoFrame> frame_buffer;
+    boost::mutex write_mutex;
+    boost::mutex frame_buffer_mutex;
+    boost::mutex frames_available_mutex;
+    boost::condition_variable frames_available_cond;
+    bool frames_available;
+    boost::thread frame_writer_thread;
+  };
+} // namespace malmo

--- a/external/malmo/Malmo/src/MissionRecord.h
+++ b/external/malmo/Malmo/src/MissionRecord.h
@@ -1,28 +1,30 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _MISSIONRECORD_H_
-#define _MISSIONRECORD_H_
+#pragma once
 
 // Local:
-#include "Tarball.hpp"
 #include "MissionRecordSpec.h"
+#include "Tarball.hpp"
 
 // Boost:
 #include <boost/filesystem.hpp>
@@ -33,123 +35,123 @@
 #include <string>
 #include <vector>
 
-namespace malmo
-{
-    //! Handles the mission record file.
-    class MissionRecord
-    {
-        public:        
-            //! Constructs a mission record handler with the provided specification
-            MissionRecord(const MissionRecordSpec& spec);
+namespace malmo {
+  //! Handles the mission record file.
+  class MissionRecord {
+  public:
+    //! Constructs a mission record handler with the provided specification
+    MissionRecord(const MissionRecordSpec& spec);
 
-            MissionRecord(MissionRecord&& record);
-            MissionRecord& operator= (MissionRecord&& record);
+    MissionRecord(MissionRecord&& record);
+    MissionRecord& operator=(MissionRecord&& record);
 
-            MissionRecord(const MissionRecord&) = delete;
-            MissionRecord& operator= (const MissionRecord&) = delete;
-            
-            //! Finalizes the mission record, closing the record if that has not already been performed.
-            ~MissionRecord();
+    MissionRecord(const MissionRecord&) = delete;
+    MissionRecord& operator=(const MissionRecord&) = delete;
 
-            //! Saves the recording to file.
-            //! Only call this once per instance of MissionRecord, after all the missions have finished,
-            //! else the paths returned by e.g. getVideoPath() will be invalid.
-            void close();
+    //! Finalizes the mission record, closing the record if that has not already
+    //! been performed.
+    ~MissionRecord();
 
-            //! Gets whether the mission will be recorded or not.
-            //! \returns Boolean value.
-            bool isRecording() const;
+    //! Saves the recording to file.
+    //! Only call this once per instance of MissionRecord, after all the
+    //! missions have finished, else the paths returned by e.g. getVideoPath()
+    //! will be invalid.
+    void close();
 
-            //! Gets whether the observations from the mission will be recorded or not.
-            //! \returns Boolean value.
-            bool isRecordingObservations() const;
+    //! Gets whether the mission will be recorded or not.
+    //! \returns Boolean value.
+    bool isRecording() const;
 
-            //! Gets whether the rewards from the mission will be recorded or not.
-            //! \returns Boolean value.
-            bool isRecordingRewards() const;
+    //! Gets whether the observations from the mission will be recorded or not.
+    //! \returns Boolean value.
+    bool isRecordingObservations() const;
 
-            //! Gets whether the commands sent during the mission will be recorded or not.
-            //! \returns Boolean value.
-            bool isRecordingCommands() const;
+    //! Gets whether the rewards from the mission will be recorded or not.
+    //! \returns Boolean value.
+    bool isRecordingRewards() const;
 
-            //! Gets the path where the mp4 video should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getMP4Path() const;
+    //! Gets whether the commands sent during the mission will be recorded or
+    //! not. \returns Boolean value.
+    bool isRecordingCommands() const;
 
-            //! Gets the path where the mp4 depth video should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getMP4DepthPath() const;
+    //! Gets the path where the mp4 video should be saved to, if recording has
+    //! been requested. \returns The path as a string.
+    std::string getMP4Path() const;
 
-            //! Gets the path where the mp4 luminance video should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getMP4LuminancePath() const;
+    //! Gets the path where the mp4 depth video should be saved to, if recording
+    //! has been requested. \returns The path as a string.
+    std::string getMP4DepthPath() const;
 
-            //! Gets the path where the mp4 colourmap video should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getMP4ColourMapPath() const;
+    //! Gets the path where the mp4 luminance video should be saved to, if
+    //! recording has been requested. \returns The path as a string.
+    std::string getMP4LuminancePath() const;
 
-            //! Gets the bitrate at which the video should be recorded, if MP4 recording has been requested.
-            //! \returns The bitrate in bits per second.
-            int64_t getMP4BitRate(TimestampedVideoFrame::FrameType type) const;
+    //! Gets the path where the mp4 colourmap video should be saved to, if
+    //! recording has been requested. \returns The path as a string.
+    std::string getMP4ColourMapPath() const;
 
-            //! Gets the frequency at which frames should be recorded, if MP4 recording has been requested.
-            //! \returns The frames per second.
-            int getMP4FramesPerSecond(TimestampedVideoFrame::FrameType type) const;
+    //! Gets the bitrate at which the video should be recorded, if MP4 recording
+    //! has been requested. \returns The bitrate in bits per second.
+    int64_t getMP4BitRate(TimestampedVideoFrame::FrameType type) const;
 
-            //! Gets whether or not the specified video type is being recorded to MP4.
-            //! \returns Boolean value.
-            bool isRecordingMP4(TimestampedVideoFrame::FrameType type) const;
+    //! Gets the frequency at which frames should be recorded, if MP4 recording
+    //! has been requested. \returns The frames per second.
+    int getMP4FramesPerSecond(TimestampedVideoFrame::FrameType type) const;
 
-            //! Gets whether or not the specified video type is dropping input frames to cap the fps.
-            bool isDroppingFrames(TimestampedVideoFrame::FrameType type) const;
+    //! Gets whether or not the specified video type is being recorded to MP4.
+    //! \returns Boolean value.
+    bool isRecordingMP4(TimestampedVideoFrame::FrameType type) const;
 
-            //! Gets whether or not the specified video type is being recorded to individual frames.
-            //! \returns Boolean value.
-            bool isRecordingBmps(TimestampedVideoFrame::FrameType type) const;
+    //! Gets whether or not the specified video type is dropping input frames to
+    //! cap the fps.
+    bool isDroppingFrames(TimestampedVideoFrame::FrameType type) const;
 
-            //! Gets the path where the observations should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getObservationsPath() const;
+    //! Gets whether or not the specified video type is being recorded to
+    //! individual frames. \returns Boolean value.
+    bool isRecordingBmps(TimestampedVideoFrame::FrameType type) const;
 
-            //! Gets the path where the rewards should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getRewardsPath() const;
+    //! Gets the path where the observations should be saved to, if recording
+    //! has been requested. \returns The path as a string.
+    std::string getObservationsPath() const;
 
-            //! Gets the path where the commands should be saved to, if recording has been requested.
-            //! \returns The path as a string.
-            std::string getCommandsPath() const;
+    //! Gets the path where the rewards should be saved to, if recording has
+    //! been requested. \returns The path as a string.
+    std::string getRewardsPath() const;
 
-            //! Gets the path where the mission init should be saved to
-            //! \returns The path as a string
-            std::string getMissionInitPath() const;
+    //! Gets the path where the commands should be saved to, if recording has
+    //! been requested. \returns The path as a string.
+    std::string getCommandsPath() const;
 
-            //! Gets the path where the mission ended should be saved to
-            //! \returns The path as a string
-            std::string getMissionEndedPath() const;
+    //! Gets the path where the mission init should be saved to
+    //! \returns The path as a string
+    std::string getMissionInitPath() const;
 
-            //! Gets the temporary directory for this mission record.
-            //! \returns The temporary directory for the mission record.
-            std::string getTemporaryDirectory() const;
+    //! Gets the path where the mission ended should be saved to
+    //! \returns The path as a string
+    std::string getMissionEndedPath() const;
 
-        private:
-            MissionRecordSpec spec;
-            bool is_closed;
+    //! Gets the temporary directory for this mission record.
+    //! \returns The temporary directory for the mission record.
+    std::string getTemporaryDirectory() const;
 
-            std::string mp4_path;
-            std::string mp4_depth_path;
-            std::string mp4_luminance_path;
-            std::string mp4_colourmap_path;
-            std::string observations_path;
-            std::string rewards_path;
-            std::string commands_path;
-            std::string mission_init_path;
-            std::string mission_ended_path;
-            std::string mission_id;
-            boost::filesystem::path temp_dir;
+  private:
+    MissionRecordSpec spec;
+    bool is_closed;
 
-            void addFiles(std::vector<boost::filesystem::path> &fileList, boost::filesystem::path directory);
-            void addFile(lindenb::io::Tar& archive, boost::filesystem::path path);
-    };
-}
+    std::string mp4_path;
+    std::string mp4_depth_path;
+    std::string mp4_luminance_path;
+    std::string mp4_colourmap_path;
+    std::string observations_path;
+    std::string rewards_path;
+    std::string commands_path;
+    std::string mission_init_path;
+    std::string mission_ended_path;
+    std::string mission_id;
+    boost::filesystem::path temp_dir;
 
-#endif
+    void addFiles(std::vector<boost::filesystem::path>& fileList,
+                  boost::filesystem::path directory);
+    void addFile(lindenb::io::Tar& archive, boost::filesystem::path path);
+  };
+} // namespace malmo

--- a/external/malmo/Malmo/src/MissionRecordSpec.h
+++ b/external/malmo/Malmo/src/MissionRecordSpec.h
@@ -1,24 +1,26 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _MISSIONRECORDSPEC_H_
-#define _MISSIONRECORDSPEC_H_
+#pragma once
 
 // Boost:
 #include <boost/filesystem.hpp>
@@ -35,84 +37,87 @@
 
 #define LOG_COMPONENT Logger::LOG_RECORDING
 
-namespace malmo
-{
-    //! Specifies the type of data that should be recorded from the mission.
-    struct MissionRecordSpec
-    {
-        MALMO_LOGGABLE_OBJECT(MissionRecordSpec)
-        friend class MissionRecord;
-        
-    public:
+namespace malmo {
+  //! Specifies the type of data that should be recorded from the mission.
+  struct MissionRecordSpec {
+    MALMO_LOGGABLE_OBJECT(MissionRecordSpec)
+    friend class MissionRecord;
 
-        //! Constructs an empty mission record specification, saying that nothing should be recorded.
-        MissionRecordSpec();
+  public:
+    //! Constructs an empty mission record specification, saying that nothing
+    //! should be recorded.
+    MissionRecordSpec();
 
-        //! Constructs a mission record with a target file (e.g. 'data.tgz').
-        //! By default, nothing is recorded. Use the other functions to specify what channels should be recorded.
-        //! WARNING: You cannot re-use the instance of MissionRecordSpec - make a new one per call to AgentHost.startMission.
-        //! \param destination Filename to save to.
-        MissionRecordSpec(std::string destination);
+    //! Constructs a mission record with a target file (e.g. 'data.tgz').
+    //! By default, nothing is recorded. Use the other functions to specify what
+    //! channels should be recorded. WARNING: You cannot re-use the instance of
+    //! MissionRecordSpec - make a new one per call to AgentHost.startMission.
+    //! \param destination Filename to save to.
+    MissionRecordSpec(std::string destination);
 
-        //! Specifies the destination for the recording.
-        void setDestination(const std::string& destination);
+    //! Specifies the destination for the recording.
+    void setDestination(const std::string& destination);
 
-        //! Requests that video be recorded, for *each* video producer, at the specified quality.
-        //! Ensure that the width of the video requested is divisible by 4, and the height of the video requested is divisible by 2.
-        //! Bitmaps and MP4 cannot both be recorded for a given video producer;
-        //! whichever is called last out of recordMP4 and recordBitmaps will take effect.
-        //! \param frames_per_second The number of frames to record per second. e.g. 20.
-        //! \param bit_rate The bit rate to record at. e.g. 400000 for 400kbps.
-        void recordMP4(int frames_per_second, int64_t bit_rate);
+    //! Requests that video be recorded, for *each* video producer, at the
+    //! specified quality. Ensure that the width of the video requested is
+    //! divisible by 4, and the height of the video requested is divisible by 2.
+    //! Bitmaps and MP4 cannot both be recorded for a given video producer;
+    //! whichever is called last out of recordMP4 and recordBitmaps will take
+    //! effect.
+    //! \param frames_per_second The number of frames to record per second. e.g. 20.
+    //! \param bit_rate The bit rate to record at. e.g. 400000 for 400kbps.
+    void recordMP4(int frames_per_second, int64_t bit_rate);
 
-        //! Requests that video be recorded, for the specified video producer, at the specified quality.
-        //! Ensure that the width of the video requested is divisible by 4, and the height of the video requested is divisible by 2.
-        //! \param frames_per_second The number of frames to output per second. e.g. 24.
-        //! \param bit_rate The bit rate to record at. e.g. 400000 for 400kbps.
-        //! \param drop_input_frames If true, will drop input frames to match frames_per_second (default behaviour) - pass false to avoid losing data.
-        //! Bitmaps and MP4 cannot both be recorded for a given video producer;
-        //! whichever is called last out of recordMP4 and recordBitmaps will take effect.
-        void recordMP4(TimestampedVideoFrame::FrameType type, int frames_per_second, int64_t bit_rate, bool drop_input_frames);
+    //! Requests that video be recorded, for the specified video producer, at
+    //! the specified quality. Ensure that the width of the video requested is
+    //! divisible by 4, and the height of the video requested is divisible by 2.
+    //! \param frames_per_second The number of frames to output per second. e.g. 24.
+    //! \param bit_rate The bit rate to record at. e.g. 400000 for 400kbps.
+    //! \param drop_input_frames If true, will drop input frames to match frames_per_second (default behaviour) - pass false to avoid losing data.
+    //! Bitmaps and MP4 cannot both be recorded for a given video producer;
+    //! whichever is called last out of recordMP4 and recordBitmaps will take
+    //! effect.
+    void recordMP4(TimestampedVideoFrame::FrameType type,
+                   int frames_per_second,
+                   int64_t bit_rate,
+                   bool drop_input_frames);
 
-        //! Requests that video be recorded, for the specified video producer, in individual bitmap frames.
-        //! Bitmaps and MP4 cannot both be recorded for a given video producer;
-        //! whichever is called last out of recordMP4 and recordBitmaps will take effect.
-        void recordBitmaps(TimestampedVideoFrame::FrameType type);
+    //! Requests that video be recorded, for the specified video producer, in
+    //! individual bitmap frames. Bitmaps and MP4 cannot both be recorded for a
+    //! given video producer; whichever is called last out of recordMP4 and
+    //! recordBitmaps will take effect.
+    void recordBitmaps(TimestampedVideoFrame::FrameType type);
 
-        //! Requests that observations be recorded.
-        void recordObservations();
+    //! Requests that observations be recorded.
+    void recordObservations();
 
-        //! Requests that rewards be recorded.
-        void recordRewards();
+    //! Requests that rewards be recorded.
+    void recordRewards();
 
-        //! Requests that commands be recorded.
-        void recordCommands();
+    //! Requests that commands be recorded.
+    void recordCommands();
 
-        //! Are we recording anything?
-        bool isRecording() const;
+    //! Are we recording anything?
+    bool isRecording() const;
 
-        friend std::ostream& operator<<(std::ostream& os, const MissionRecordSpec& msp);
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const MissionRecordSpec& msp);
 
-    private:
-        enum FrameRecordingType
-        {
-            BMP,
-            VIDEO
-        };
-        struct FrameRecordingSpec
-        {
-            FrameRecordingType fr_type;
-            int64_t mp4_bit_rate;
-            int mp4_fps;
-            bool drop_input_frames;
-        };
-        std::map<TimestampedVideoFrame::FrameType, FrameRecordingSpec> video_recordings;
-        bool is_recording_observations;
-        bool is_recording_rewards;
-        bool is_recording_commands;
-        std::string destination;
+  private:
+    enum FrameRecordingType { BMP, VIDEO };
+    struct FrameRecordingSpec {
+      FrameRecordingType fr_type;
+      int64_t mp4_bit_rate;
+      int mp4_fps;
+      bool drop_input_frames;
     };
-}
+    std::map<TimestampedVideoFrame::FrameType, FrameRecordingSpec>
+        video_recordings;
+    bool is_recording_observations;
+    bool is_recording_rewards;
+    bool is_recording_commands;
+    std::string destination;
+  };
+} // namespace malmo
 
 #undef LOG_COMPONENT
-#endif

--- a/external/malmo/Malmo/src/PosixFrameWriter.cpp
+++ b/external/malmo/Malmo/src/PosixFrameWriter.cpp
@@ -147,6 +147,7 @@ namespace malmo {
                    to_string(this->bit_rate).c_str(),
                    "-pix_fmt",
                    "yuv420p",
+                   "-copyts",
                    this->path.c_str(),
                    NULL);
       if (ret)

--- a/external/malmo/Malmo/src/PosixFrameWriter.cpp
+++ b/external/malmo/Malmo/src/PosixFrameWriter.cpp
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
@@ -35,215 +38,235 @@
 
 #define LOG_COMPONENT Logger::LOG_VIDEO
 
-namespace malmo
-{
-    std::stack<PosixFrameWriter::pid_fd> PosixFrameWriter::child_process_stack;
-    std::vector<PosixFrameWriter::pid_fd> PosixFrameWriter::child_processes_pending_deletion;
+using namespace std;
+namespace fs = boost::filesystem;
 
-    PosixFrameWriter::PosixFrameWriter(std::string path, std::string info_filename, short width, short height, int frames_per_second, int64_t bit_rate, int channels, bool drop_input_frames)
-        : VideoFrameWriter(path, info_filename, width, height, frames_per_second, channels, drop_input_frames)
-        , bit_rate(bit_rate)
-        , process_id(0)
-    {
-        this->ffmpeg_path = search_path();
-        if (this->ffmpeg_path.length() == 0) {
-            throw std::runtime_error( "FFMPEG not available. For .mp4 recording, install ffmpeg (or libav-tools)." );
-        }
+namespace malmo {
+  stack<PosixFrameWriter::pid_fd> PosixFrameWriter::child_process_stack;
+  vector<PosixFrameWriter::pid_fd>
+      PosixFrameWriter::child_processes_pending_deletion;
 
-        int ret = pipe( this->pipe_fd );
-        if( ret )
-            throw std::runtime_error( "Failed to create pipe." );
+  PosixFrameWriter::PosixFrameWriter(string path,
+                                     string info_filename,
+                                     short width,
+                                     short height,
+                                     int frames_per_second,
+                                     int64_t bit_rate,
+                                     int channels,
+                                     bool drop_input_frames)
+      : VideoFrameWriter(path,
+                         info_filename,
+                         width,
+                         height,
+                         frames_per_second,
+                         channels,
+                         drop_input_frames),
+        bit_rate(bit_rate), process_id(0) {
+    this->ffmpeg_path = search_path();
+    if (this->ffmpeg_path.length() == 0) {
+      throw runtime_error("FFMPEG not available. For .mp4 recording, install "
+                          "ffmpeg (or libav-tools).");
     }
 
-    void PosixFrameWriter::open()
-    {
-        VideoFrameWriter::open();
-        
-        this->process_id = fork();
-        if( this->process_id < 0 )
-            throw std::runtime_error( "Failed to fork." );
-        
-        int ret;
+    int ret = pipe(this->pipe_fd);
+    if (ret)
+      throw runtime_error("Failed to create pipe.");
+  }
 
-        if( this->process_id ) 
-        {
-            // this is the parent process, can write to pipe_fd[1]
-            // push our child's proc id onto the stack:
-            child_process_stack.push(std::make_pair(this->process_id, this->pipe_fd[1]));
-            ret = ::close( this->pipe_fd[0] ); // close the end of the pipe we don't want to use
-            if( ret )
-                throw std::runtime_error( "Failed to close unused pipe end." );
-        } 
-        else 
-        {
-            // this is the child process, replace it with ffmpeg
-            
-            ret = dup2( this->pipe_fd[0], 0 );     // map stdin to pipe_fd[0]
-            if( ret < 0 )
-                throw std::runtime_error( "Failed to map stdin to pipe." );
+  void PosixFrameWriter::open() {
+    VideoFrameWriter::open();
 
-            ret = ::close( this->pipe_fd[1] ); // close the end of the pipe we don't want to use
-            if( ret )
-                throw std::runtime_error( "Failed to close unused pipe end." );
+    this->process_id = fork();
+    if (this->process_id < 0)
+      throw runtime_error("Failed to fork.");
 
-            // send ffmpeg's output to file
-            {
-                boost::filesystem::path fs_path(this->path);
-                std::string ffmpeg_outfile = (fs_path.parent_path() / (fs_path.stem().string() + "_ffmpeg.out")).string();
+    int ret;
 
-                int out_fd = ::open(ffmpeg_outfile.c_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
-                if( out_fd < 0 )
-                    throw std::runtime_error( "Failed to open ffmpeg.out for writing." );
-                    
-                ret = dup2(out_fd, 1); // stdout
-                if( ret < 0 )
-                    throw std::runtime_error( "Failed to map ffmpeg's stdout to file." );
-                    
-                ret = dup2(out_fd, 2); // stderr
-                if( ret < 0 )
-                    throw std::runtime_error( "Failed to map ffmpeg's stderr to file." );
-
-                ret = ::close(out_fd); 
-                if( ret )
-                    throw std::runtime_error( "Failed to close ffmpeg.out file descriptor." );
-            }
-
-            std::string input_format = this->channels == 1 ? "pgm" : "ppm";
-
-            ret = execlp( this->ffmpeg_path.c_str(), 
-                          this->ffmpeg_path.c_str(),
-                          "-y",
-                          "-f",
-                          "image2pipe",
-                          "-framerate",
-                          std::to_string(this->frames_per_second).c_str(),
-                          "-vcodec",
-                          input_format.c_str(),
-                          "-i",
-                          "-",
-                          "-vcodec",
-                          "libx264",
-                          "-b:v",
-                          std::to_string(this->bit_rate).c_str(),
-                          "-pix_fmt",
-                          "yuv420p",
-                          this->path.c_str(),
-                          NULL
-                    );
-            if( ret )
-                throw std::runtime_error( "Call to execlp failed." );
-        }
+    if (this->process_id) {
+      // this is the parent process, can write to pipe_fd[1]
+      // push our child's proc id onto the stack:
+      child_process_stack.push(make_pair(this->process_id, this->pipe_fd[1]));
+      ret = ::close(
+          this->pipe_fd[0]); // close the end of the pipe we don't want to use
+      if (ret)
+        throw runtime_error("Failed to close unused pipe end.");
     }
+    else {
+      // this is the child process, replace it with ffmpeg
 
-    PosixFrameWriter::~PosixFrameWriter()
-    {
-        LOGFINE(LT("Destructing PosixFrameWriter - calling close()"));
-        this->close();
-    }
+      ret = dup2(this->pipe_fd[0], 0); // map stdin to pipe_fd[0]
+      if (ret < 0)
+        throw runtime_error("Failed to map stdin to pipe.");
 
-    void PosixFrameWriter::close()
-    {
-        LOGFINE(LT("In PosixFrameWriter::close()"));
-        if (this->is_open)
-        {
-            VideoFrameWriter::close();
-        }
+      ret = ::close(
+          this->pipe_fd[1]); // close the end of the pipe we don't want to use
+      if (ret)
+        throw runtime_error("Failed to close unused pipe end.");
 
-        // if the parent process then close the pipe and wait for ffmpeg to finish
-        // it's VERY important we do this in reverse order of creation, since later child processes
-        // will be holding handles to previous child processes (they inherit the full fd table from the
-        // parent.) Closing them first ensures that all handles have been closed by the time the first
-        // child processes are closed.
-        if (this->process_id)
-        {
-            LOGFINE(LT("Parent PosixFrameWriter process requesting pipe close - fd: "), this->pipe_fd[1], LT(" pid: "), this->process_id);
-            child_processes_pending_deletion.push_back(std::make_pair(this->process_id, this->pipe_fd[1]));
-            this->process_id = 0;
-            close_pending_children();
-        }
-    }
+      // send ffmpeg's output to file
+      {
+        fs::path fs_path(this->path);
+        string ffmpeg_outfile =
+            (fs_path.parent_path() / (fs_path.stem().string() + "_ffmpeg.out"))
+                .string();
 
-    void PosixFrameWriter::close_pending_children()
-    {
-        // we can only close the process at the top of the stack.
-        while (child_process_stack.size() && std::find(child_processes_pending_deletion.begin(), child_processes_pending_deletion.end(), child_process_stack.top()) != child_processes_pending_deletion.end())
-        {
-            pid_fd child = child_process_stack.top();
-            child_process_stack.pop();
-            LOGFINE(LT("Parent PosixFrameWriter process is closing pipe - fd: "), child.second, LT(" pid: "), child.first);
-            int ret = ::close(child.second);
-            if (ret)
-            {
-                LOGERROR(LT("Failed to close pipe: "), ret);
-                throw std::runtime_error("Failed to close the pipe.");
-            }
+        int out_fd = ::open(
+            ffmpeg_outfile.c_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+        if (out_fd < 0)
+          throw runtime_error("Failed to open ffmpeg.out for writing.");
 
-            int status;
-            LOGFINE(LT("Pipe closed, waiting for ffmpeg to end..."));
-            ret = waitpid( child.first, &status, 0 );
-            if (ret != child.first)
-            {
-                LOGERROR(LT("Call to waitpid failed: "), ret);
-                throw std::runtime_error("Call to waitpid failed.");
-            }
-            if (!WIFEXITED(status))
-            {
-                LOGERROR(LT("FFMPEG process exited abnormally: "), status);
-                throw std::runtime_error("FFMPEG process exited abnormally.");
-            }
-        }
-    }
-
-    void PosixFrameWriter::doWrite(char* rgb, int width, int height, int frame_index)
-    {
-        std::string magic_number = this->channels == 1 ? "P5" : "P6";
-        std::ostringstream oss;
-        oss << magic_number << "\n" << width << " " << height << "\n255\n";
-        ssize_t ret = ::write( this->pipe_fd[1], oss.str().c_str(), oss.str().size() );
+        ret = dup2(out_fd, 1); // stdout
         if (ret < 0)
-        {
-            LOGERROR(LT("Failed to write frame header: "), std::strerror(errno), LT(" - throwing runtime_error"));
-            throw std::runtime_error("Call to write failed.");
-        }
+          throw runtime_error("Failed to map ffmpeg's stdout to file.");
 
-        ret = ::write( this->pipe_fd[1], rgb, width*height*this->channels );
+        ret = dup2(out_fd, 2); // stderr
         if (ret < 0)
-        {
-            LOGERROR(LT("Failed to write frame body: "), std::strerror(errno), LT(" - throwing runtime_error"));
-            throw std::runtime_error("Call to write failed.");
-        }
+          throw runtime_error("Failed to map ffmpeg's stderr to file.");
+
+        ret = ::close(out_fd);
+        if (ret)
+          throw runtime_error("Failed to close ffmpeg.out file descriptor.");
+      }
+
+      string input_format = this->channels == 1 ? "pgm" : "ppm";
+
+      ret = execlp(this->ffmpeg_path.c_str(),
+                   this->ffmpeg_path.c_str(),
+                   "-y",
+                   "-f",
+                   "image2pipe",
+                   "-framerate",
+                   to_string(this->frames_per_second).c_str(),
+                   "-vcodec",
+                   input_format.c_str(),
+                   "-i",
+                   "-",
+                   "-vcodec",
+                   "libx264",
+                   "-b:v",
+                   to_string(this->bit_rate).c_str(),
+                   "-pix_fmt",
+                   "yuv420p",
+                   this->path.c_str(),
+                   NULL);
+      if (ret)
+        throw runtime_error("Call to execlp failed.");
+    }
+  }
+
+  PosixFrameWriter::~PosixFrameWriter() {
+    LOGFINE(LT("Destructing PosixFrameWriter - calling close()"));
+    this->close();
+  }
+
+  void PosixFrameWriter::close() {
+    LOGFINE(LT("In PosixFrameWriter::close()"));
+    if (this->is_open) {
+      VideoFrameWriter::close();
     }
 
-    std::string PosixFrameWriter::search_path()
-    {
-        std::string path = ::getenv("PATH");
-        if (path.empty())
-        {
-            throw std::runtime_error("Environment variable PATH not found");
-        }
-
-        std::stringstream path_stream(path);
-        std::string folder_path;
-        
-        std::string ffmpeg_names[2] = { "ffmpeg", "avconv" };
-
-        while (std::getline(path_stream, folder_path, ':')) {
-            for( auto ffmpeg_name : ffmpeg_names ) {
-                boost::filesystem::path executable_path = folder_path;
-                executable_path /= ffmpeg_name;
-
-                boost::system::error_code ec;
-                bool file = boost::filesystem::is_regular_file(executable_path, ec);
-                bool is_executable = !access( executable_path.string().c_str(), X_OK );
-                if (!ec && file && is_executable)
-                {
-                    return executable_path.string();
-                }
-            }
-        }
-
-        return "";
+    // if the parent process then close the pipe and wait for ffmpeg to finish
+    // it's VERY important we do this in reverse order of creation, since later
+    // child processes will be holding handles to previous child processes (they
+    // inherit the full fd table from the parent.) Closing them first ensures
+    // that all handles have been closed by the time the first child processes
+    // are closed.
+    if (this->process_id) {
+      LOGFINE(
+          LT("Parent PosixFrameWriter process requesting pipe close - fd: "),
+          this->pipe_fd[1],
+          LT(" pid: "),
+          this->process_id);
+      child_processes_pending_deletion.push_back(
+          make_pair(this->process_id, this->pipe_fd[1]));
+      this->process_id = 0;
+      close_pending_children();
     }
-}
+  }
+
+  void PosixFrameWriter::close_pending_children() {
+    // we can only close the process at the top of the stack.
+    while (child_process_stack.size() &&
+           find(child_processes_pending_deletion.begin(),
+                child_processes_pending_deletion.end(),
+                child_process_stack.top()) !=
+               child_processes_pending_deletion.end()) {
+      pid_fd child = child_process_stack.top();
+      child_process_stack.pop();
+      LOGFINE(LT("Parent PosixFrameWriter process is closing pipe - fd: "),
+              child.second,
+              LT(" pid: "),
+              child.first);
+      int ret = ::close(child.second);
+      if (ret) {
+        LOGERROR(LT("Failed to close pipe: "), ret);
+        throw runtime_error("Failed to close the pipe.");
+      }
+
+      int status;
+      LOGFINE(LT("Pipe closed, waiting for ffmpeg to end..."));
+      ret = waitpid(child.first, &status, 0);
+      if (ret != child.first) {
+        LOGERROR(LT("Call to waitpid failed: "), ret);
+        throw runtime_error("Call to waitpid failed.");
+      }
+      if (!WIFEXITED(status)) {
+        LOGERROR(LT("FFMPEG process exited abnormally: "), status);
+        throw runtime_error("FFMPEG process exited abnormally.");
+      }
+    }
+  }
+
+  void
+  PosixFrameWriter::doWrite(char* rgb, int width, int height, int frame_index) {
+    string magic_number = this->channels == 1 ? "P5" : "P6";
+    ostringstream oss;
+    oss << magic_number << "\n" << width << " " << height << "\n255\n";
+    ssize_t ret =
+        ::write(this->pipe_fd[1], oss.str().c_str(), oss.str().size());
+    if (ret < 0) {
+      LOGERROR(LT("Failed to write frame header: "),
+               strerror(errno),
+               LT(" - throwing runtime_error"));
+      throw runtime_error("Call to write failed.");
+    }
+
+    ret = ::write(this->pipe_fd[1], rgb, width * height * this->channels);
+    if (ret < 0) {
+      LOGERROR(LT("Failed to write frame body: "),
+               strerror(errno),
+               LT(" - throwing runtime_error"));
+      throw runtime_error("Call to write failed.");
+    }
+  }
+
+  string PosixFrameWriter::search_path() {
+    string path = ::getenv("PATH");
+    if (path.empty()) {
+      throw runtime_error("Environment variable PATH not found");
+    }
+
+    stringstream path_stream(path);
+    string folder_path;
+
+    string ffmpeg_names[2] = {"ffmpeg", "avconv"};
+
+    while (getline(path_stream, folder_path, ':')) {
+      for (auto ffmpeg_name : ffmpeg_names) {
+        fs::path executable_path = folder_path;
+        executable_path /= ffmpeg_name;
+
+        boost::system::error_code ec;
+        bool file = fs::is_regular_file(executable_path, ec);
+        bool is_executable = !access(executable_path.string().c_str(), X_OK);
+        if (!ec && file && is_executable) {
+          return executable_path.string();
+        }
+      }
+    }
+
+    return "";
+  }
+} // namespace malmo
 
 #undef LOG_COMPONENT

--- a/external/malmo/Malmo/src/PosixFrameWriter.h
+++ b/external/malmo/Malmo/src/PosixFrameWriter.h
@@ -1,54 +1,58 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _POSIXFRAMEWRITER_H_
-#define _POSIXFRAMEWRITER_H_
+#pragma once
 
 // Local:
 #include "VideoFrameWriter.h"
 
-namespace malmo
-{
-    class PosixFrameWriter : public VideoFrameWriter
-    {
-    public:
+namespace malmo {
+  class PosixFrameWriter : public VideoFrameWriter {
+  public:
+    PosixFrameWriter(std::string path,
+                     std::string info_filename,
+                     short width,
+                     short height,
+                     int frames_per_second,
+                     int64_t bit_rate = 400000,
+                     int channels = 3,
+                     bool drop_input_frames = false);
+    ~PosixFrameWriter();
+    void open() override;
+    void close() override;
 
-        PosixFrameWriter(std::string path, std::string info_filename, short width, short height, int frames_per_second, int64_t bit_rate = 400000, int channels = 3, bool drop_input_frames = false);
-        ~PosixFrameWriter();
-        void open() override;
-        void close() override;
+  private:
+    void doWrite(char* rgb, int width, int height, int frame_index) override;
+    std::string search_path();
 
-    private:
-        void doWrite(char* rgb, int width, int height, int frame_index) override;
-        std::string search_path();
-        
-        int64_t bit_rate;
-        std::string ffmpeg_path;
-        
-        int pipe_fd[2];
-        pid_t process_id;
+    int64_t bit_rate;
+    std::string ffmpeg_path;
 
-        typedef std::pair<pid_t, int> pid_fd;
-        static std::stack<pid_fd> child_process_stack;
-        static std::vector<pid_fd> child_processes_pending_deletion;
-        static void close_pending_children();
-    };
-}
+    int pipe_fd[2];
+    pid_t process_id;
 
-#endif
+    typedef std::pair<pid_t, int> pid_fd;
+    static std::stack<pid_fd> child_process_stack;
+    static std::vector<pid_fd> child_processes_pending_deletion;
+    static void close_pending_children();
+  };
+} // namespace malmo

--- a/external/malmo/Malmo/src/StringServer.cpp
+++ b/external/malmo/Malmo/src/StringServer.cpp
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
@@ -26,84 +29,77 @@
 
 #include <iostream>
 
+using namespace std;
+
 namespace malmo {
-    StringServer::StringServer(boost::asio::io_service& io_service, int port, const boost::function<void(const TimestampedString string_message)> handle_string, const std::string& log_name)
-        : handle_string(handle_string)
-        , io_service(io_service)
-        , port(port)
-        , log_name(log_name)
-    {
+  StringServer::StringServer(
+      boost::asio::io_service& io_service,
+      int port,
+      const boost::function<void(const TimestampedString string_message)>
+          handle_string,
+      const string& log_name)
+      : handle_string(handle_string), io_service(io_service), port(port),
+        log_name(log_name) {}
+
+  void StringServer::start(boost::shared_ptr<StringServer>& scope) {
+    this->server = boost::make_shared<TCPServer>(
+        this->io_service,
+        this->port,
+        boost::bind(&StringServer::handleMessage, scope, _1),
+        this->log_name);
+    this->scope = scope;
+    this->server->start(scope.get());
+  }
+
+  void StringServer::close() { this->server->close(); }
+
+  void StringServer::release() { this->scope = 0; }
+
+  StringServer& StringServer::record(string path) {
+    if (this->writer.is_open()) {
+      this->writer.close();
     }
 
-    void StringServer::start(boost::shared_ptr<StringServer>& scope)
-    {
-        this->server = boost::make_shared<TCPServer>(this->io_service, this->port, boost::bind(&StringServer::handleMessage, scope, _1), this->log_name);
-        this->scope = scope;
-        this->server->start(scope.get());
+    this->writer.open(path, ofstream::out | ofstream::app);
+
+    return *this;
+  }
+
+  StringServer& StringServer::confirmWithFixedReply(string reply) {
+    this->server->confirmWithFixedReply(reply);
+    return *this;
+  }
+
+  StringServer& StringServer::expectSizeHeader(bool expect_size_header) {
+    this->server->expectSizeHeader(expect_size_header);
+    return *this;
+  }
+
+  void
+  StringServer::handleMessage(const TimestampedUnsignedCharVector message) {
+    TimestampedString string_message(message);
+
+    this->handle_string(string_message);
+
+    this->recordMessage(string_message);
+  }
+
+  void StringServer::stopRecording() {
+    if (this->writer.is_open()) {
+      boost::lock_guard<boost::mutex> scope_guard(this->write_mutex);
+
+      this->writer.close();
     }
+  }
 
-    void StringServer::close() {
-        this->server->close();
+  int StringServer::getPort() const { return this->server->getPort(); }
+
+  void StringServer::recordMessage(const TimestampedString string_message) {
+    if (this->writer.is_open()) {
+      boost::lock_guard<boost::mutex> scope_guard(this->write_mutex);
+
+      this->writer << boost::posix_time::to_iso_string(string_message.timestamp)
+                   << " " << string_message.text << endl;
     }
-
-    void StringServer::release() {
-        this->scope = 0;
-    }
-
-    StringServer& StringServer::record(std::string path)
-    {
-        if (this->writer.is_open()){
-            this->writer.close();
-        }
-
-        this->writer.open(path, std::ofstream::out | std::ofstream::app);
-
-        return *this;
-    }
-    
-    StringServer& StringServer::confirmWithFixedReply(std::string reply)
-    {
-        this->server->confirmWithFixedReply(reply);
-        return *this;
-    }
-    
-    StringServer& StringServer::expectSizeHeader(bool expect_size_header)
-    {
-        this->server->expectSizeHeader(expect_size_header);
-        return *this;
-    }
-
-    void StringServer::handleMessage(const TimestampedUnsignedCharVector message)
-    {
-        TimestampedString string_message(message);
-
-        this->handle_string(string_message);
-
-        this->recordMessage(string_message);
-    }
-
-    void StringServer::stopRecording()
-    {
-        if (this->writer.is_open())
-        {
-            boost::lock_guard<boost::mutex> scope_guard(this->write_mutex);
-            
-            this->writer.close();
-        }
-    }
-
-    int StringServer::getPort() const
-    {
-        return this->server->getPort();
-    }
-
-    void StringServer::recordMessage(const TimestampedString string_message)
-    {
-        if (this->writer.is_open())
-        {
-            boost::lock_guard<boost::mutex> scope_guard(this->write_mutex);
-
-            this->writer << boost::posix_time::to_iso_string(string_message.timestamp) << " " << string_message.text << std::endl;
-        }
-    }
-}
+  }
+} // namespace malmo

--- a/external/malmo/Malmo/src/TCPClient.cpp
+++ b/external/malmo/Malmo/src/TCPClient.cpp
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
@@ -22,205 +25,275 @@
 #include "Logger.h"
 
 // Boost:
-#include <boost/thread.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/asio.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/lambda/lambda.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 
-
-using boost::asio::ip::tcp;
+using namespace std;
+using boost::asio, boost::asio::ip::tcp, boost::system;
 
 #define LOG_COMPONENT Logger::LOG_TCP
 
-namespace malmo
-{
-    void SendOverTCP(boost::asio::io_service& io_service, std::string address, int port, std::vector<unsigned char> message, bool withSizeHeader)
-    {
-        tcp::resolver resolver(io_service);
-        tcp::resolver::query query(address, boost::lexical_cast<std::string>(port));
-        tcp::resolver::iterator endpoint_iterator;
-        try
-        {
-            endpoint_iterator = resolver.resolve(query);
-        }
-        catch (boost::system::system_error e)
-        {
-            LOGERROR(LT("Failed to resolve endpoint for "), address, LT(":"), port, LT(" - "), e.code().message());
-            throw e;
-        }
-
-        tcp::socket socket(io_service);
-        try
-        {
-            boost::asio::connect(socket, endpoint_iterator);
-        }
-        catch (boost::system::system_error e)
-        {
-            LOGERROR(LT("Failed to connect to "), address, LT(":"), port, LT(" - "), e.code().message());
-            throw e;
-        }
-
-        if (withSizeHeader)
-        {
-            // the size header is 4 bytes containing the size of the body of the message as a network byte order integer
-            const int SIZE_HEADER_LENGTH = 4;
-            u_long size_header = htonl((u_long)message.size());
-            try
-            {
-                boost::asio::write(socket, boost::asio::buffer(&size_header, SIZE_HEADER_LENGTH));
-            }
-            catch (boost::system::system_error e)
-            {
-                LOGERROR(LT("Failed to write header to "), address, LT(":"), port, LT(" - "), e.code().message());
-                throw e;
-            }
-        }
-        else if (message.back() != '\n')
-        {
-            // if not sending with a size header then the message must be newline-terminated
-            message.push_back('\n');
-        }
-        
-        try
-        {
-            boost::asio::write(socket, boost::asio::buffer(message));
-        }
-        catch (boost::system::system_error e)
-        {
-            LOGERROR(LT("Failed to write message to "), address, LT(":"), port, LT(" - "), e.code().message());
-            throw e;
-        }
+namespace malmo {
+  void SendOverTCP(asio::io_service& io_service,
+                   string address,
+                   int port,
+                   vector<unsigned char> message,
+                   bool withSizeHeader) {
+    tcp::resolver resolver(io_service);
+    tcp::resolver::query query(address, boost::lexical_cast<string>(port));
+    tcp::resolver::iterator endpoint_iterator;
+    try {
+      endpoint_iterator = resolver.resolve(query);
+    }
+    catch (system::system_error e) {
+      LOGERROR(LT("Failed to resolve endpoint for "),
+               address,
+               LT(":"),
+               port,
+               LT(" - "),
+               e.code().message());
+      throw e;
     }
 
-    void SendStringOverTCP(boost::asio::io_service& io_service, std::string address, int port, std::string message, bool withSizeHeader)
-    {
-        SendOverTCP(io_service,address, port, std::vector<unsigned char>(message.begin(), message.end()), withSizeHeader);
+    tcp::socket socket(io_service);
+    try {
+      asio::connect(socket, endpoint_iterator);
+    }
+    catch (system::system_error e) {
+      LOGERROR(LT("Failed to connect to "),
+               address,
+               LT(":"),
+               port,
+               LT(" - "),
+               e.code().message());
+      throw e;
     }
 
-    std::string Rpc::sendStringAndGetShortReply(boost::asio::io_service& io_service, const std::string& ip_address, int port, const std::string& message, bool withSizeHeader)
-    {
-        const u_long MAX_PACKET_LENGTH = 1024;
-        unsigned char data[MAX_PACKET_LENGTH + 1];
-        std::vector<unsigned char> message_vector(message.begin(), message.end());
+    if (withSizeHeader) {
+      // the size header is 4 bytes containing the size of the body of the
+      // message as a network byte order integer
+      const int SIZE_HEADER_LENGTH = 4;
+      u_long size_header = htonl((u_long)message.size());
+      try {
+        asio::write(socket, asio::buffer(&size_header, SIZE_HEADER_LENGTH));
+      }
+      catch (system::system_error e) {
+        LOGERROR(LT("Failed to write header to "),
+                 address,
+                 LT(":"),
+                 port,
+                 LT(" - "),
+                 e.code().message());
+        throw e;
+      }
+    }
+    else if (message.back() != '\n') {
+      // if not sending with a size header then the message must be
+      // newline-terminated
+      message.push_back('\n');
+    }
 
-        tcp::resolver resolver(io_service);
-        tcp::resolver::query query(ip_address, boost::lexical_cast<std::string>(port));
-        tcp::socket socket(io_service);
+    try {
+      asio::write(socket, asio::buffer(message));
+    }
+    catch (system::system_error e) {
+      LOGERROR(LT("Failed to write message to "),
+               address,
+               LT(":"),
+               port,
+               LT(" - "),
+               e.code().message());
+      throw e;
+    }
+  }
 
-        // Set up a deadline timer to close the socket on timeout, aborting any async io.
+  void SendStringOverTCP(asio::io_service& io_service,
+                         string address,
+                         int port,
+                         string message,
+                         bool withSizeHeader) {
+    SendOverTCP(io_service,
+                address,
+                port,
+                vector<unsigned char>(message.begin(), message.end()),
+                withSizeHeader);
+  }
 
-        boost::asio::deadline_timer deadline(io_service, timeout);
+  string Rpc::sendStringAndGetShortReply(asio::io_service& io_service,
+                                         const string& ip_address,
+                                         int port,
+                                         const string& message,
+                                         bool withSizeHeader) {
+    const u_long MAX_PACKET_LENGTH = 1024;
+    unsigned char data[MAX_PACKET_LENGTH + 1];
+    vector<unsigned char> message_vector(message.begin(), message.end());
 
-        deadline.async_wait([&](const boost::system::error_code& ec) {
-            if (!ec)
-            {
-                LOGERROR(LT("Request/Reply communication timeout."));
-                boost::system::error_code ignored_ec;
-                socket.close(ignored_ec);
+    tcp::resolver resolver(io_service);
+    tcp::resolver::query query(ip_address, boost::lexical_cast<string>(port));
+    tcp::socket socket(io_service);
+
+    // Set up a deadline timer to close the socket on timeout, aborting any
+    // async io.
+
+    asio::deadline_timer deadline(io_service, timeout);
+
+    deadline.async_wait([&](const system::error_code& ec) {
+      if (!ec) {
+        LOGERROR(LT("Request/Reply communication timeout."));
+        system::error_code ignored_ec;
+        socket.close(ignored_ec);
+      }
+    });
+
+    // Attempt the resolve & connect. Relying on background worker thread to
+    // progress the async io.
+
+    error_code_sync.init_error_code();
+
+    resolver.async_resolve(
+        query,
+        [&](const system::error_code& ec,
+            tcp::resolver::iterator endpoint_iterator) {
+          if (ec) {
+            LOGERROR(LT("Failed to resolve "),
+                     ip_address,
+                     LT(":"),
+                     port,
+                     LT(" - "),
+                     ec.message());
+            error_code_sync.signal_error_code(ec);
+          }
+          else {
+            if (endpoint_iterator == tcp::resolver::iterator()) {
+              error_code_sync.signal_error_code(asio::error::fault);
             }
+            else {
+              socket.async_connect(
+                  endpoint_iterator->endpoint(),
+                  boost::bind(&ErrorCodeSync::signal_error_code,
+                              &this->error_code_sync,
+                              asio::placeholders::error));
+            }
+          }
         });
 
-        // Attempt the resolve & connect. Relying on background worker thread to progress the async io.
+    auto error_code = error_code_sync.await_error_code();
 
-        error_code_sync.init_error_code();
-
-        resolver.async_resolve(query, [&](const boost::system::error_code& ec, tcp::resolver::iterator endpoint_iterator) {
-            if (ec)
-            {
-                LOGERROR(LT("Failed to resolve "), ip_address, LT(":"), port, LT(" - "), ec.message());
-                error_code_sync.signal_error_code(ec);
-            }
-            else
-            {
-                if (endpoint_iterator == tcp::resolver::iterator()) {
-                    error_code_sync.signal_error_code(boost::asio::error::fault);
-                }
-                else {
-                    socket.async_connect(endpoint_iterator->endpoint(), boost::bind(&ErrorCodeSync::signal_error_code, &this->error_code_sync, boost::asio::placeholders::error));
-                }
-            }
-        });
-
-        auto error_code = error_code_sync.await_error_code();
-
-        if (error_code || !socket.is_open())
-        {
-            LOGERROR(LT("Failed to connect to "), ip_address, LT(":"), port, LT(" - "), error_code.message());
-            throw std::runtime_error("Could not connect  " + (error_code ? error_code : boost::asio::error::operation_aborted).message());
-        }
-
-        error_code_sync.init_error_code();
-
-        // The size header is 4 bytes containing the size of the body of the message as a network byte order integer.
-        const int SIZE_HEADER_LENGTH = 4;
-        u_long size_header;
-
-        if (withSizeHeader)
-        {
-            u_long size_header = htonl((u_long)message.size());
-
-            boost::asio::async_write(socket, boost::asio::buffer(&size_header, SIZE_HEADER_LENGTH), [&](const boost::system::error_code& ec, std::size_t transferred) {
-                if (!ec)
-                {
-                    boost::asio::async_write(socket, boost::asio::buffer(message_vector), boost::bind(&Rpc::transfer_handler, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-                }
-                else
-                {
-                    transfer_handler(ec, transferred);
-                }
-            });
-        }
-        else 
-        {
-            boost::asio::async_write(socket, boost::asio::buffer(message_vector), boost::bind(&Rpc::transfer_handler, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-        }
-
-        error_code = error_code_sync.await_error_code();
-
-        if (error_code)
-            throw std::runtime_error("Request write failed " + error_code.message());
-
-        error_code_sync.init_error_code();
-
-        boost::asio::async_read(socket, boost::asio::buffer(&size_header, SIZE_HEADER_LENGTH), boost::asio::transfer_exactly(SIZE_HEADER_LENGTH), 
-            [&](const boost::system::error_code& ec, std::size_t transferred) {
-                if (!ec) {
-                    size_header = ntohl(size_header);
-
-                    if (size_header > MAX_PACKET_LENGTH)
-                    {
-                        LOGERROR(LT("Packet length of "), size_header, LT(" received from "), ip_address, LT(":"), port, LT(" exceeds maximum allowed."));
-                        transfer_handler(boost::asio::error::fault, transferred);
-                    }
-                    else
-                    {
-                        boost::asio::async_read(socket, boost::asio::buffer(data, size_header), boost::asio::transfer_exactly(size_header), boost::bind(&Rpc::transfer_handler, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-                    }
-                }
-                else
-                {
-                    transfer_handler(ec, transferred);
-                }
-        });
-
-        error_code = error_code_sync.await_error_code();
-
-        if (error_code)
-            throw std::runtime_error("Response read failed " + error_code.message());
-
-        std::string reply(data, data + size_header);
-
-        if (!error_code)
-            LOGFINE(LT("Received reply from  "), ip_address, LT(":"), port, LT(" - "), reply);
-
-        return reply;
+    if (error_code || !socket.is_open()) {
+      LOGERROR(LT("Failed to connect to "),
+               ip_address,
+               LT(":"),
+               port,
+               LT(" - "),
+               error_code.message());
+      throw runtime_error(
+          "Could not connect  " +
+          (error_code ? error_code : asio::error::operation_aborted).message());
     }
 
-    void Rpc::transfer_handler(const boost::system::error_code& ec, std::size_t transferred) {
-        error_code_sync.signal_error_code(ec);
+    error_code_sync.init_error_code();
+
+    // The size header is 4 bytes containing the size of the body of the message
+    // as a network byte order integer.
+    const int SIZE_HEADER_LENGTH = 4;
+    u_long size_header;
+
+    if (withSizeHeader) {
+      u_long size_header = htonl((u_long)message.size());
+
+      asio::async_write(
+          socket,
+          asio::buffer(&size_header, SIZE_HEADER_LENGTH),
+          [&](const system::error_code& ec, size_t transferred) {
+            if (!ec) {
+              asio::async_write(
+                  socket,
+                  asio::buffer(message_vector),
+                  boost::bind(&Rpc::transfer_handler,
+                              this,
+                              asio::placeholders::error,
+                              asio::placeholders::bytes_transferred));
+            }
+            else {
+              transfer_handler(ec, transferred);
+            }
+          });
     }
-}
+    else {
+      asio::async_write(socket,
+                        asio::buffer(message_vector),
+                        boost::bind(&Rpc::transfer_handler,
+                                    this,
+                                    asio::placeholders::error,
+                                    asio::placeholders::bytes_transferred));
+    }
+
+    error_code = error_code_sync.await_error_code();
+
+    if (error_code)
+      throw runtime_error("Request write failed " + error_code.message());
+
+    error_code_sync.init_error_code();
+
+    asio::async_read(
+        socket,
+        asio::buffer(&size_header, SIZE_HEADER_LENGTH),
+        asio::transfer_exactly(SIZE_HEADER_LENGTH),
+        [&](const system::error_code& ec, size_t transferred) {
+          if (!ec) {
+            size_header = ntohl(size_header);
+
+            if (size_header > MAX_PACKET_LENGTH) {
+              LOGERROR(LT("Packet length of "),
+                       size_header,
+                       LT(" received from "),
+                       ip_address,
+                       LT(":"),
+                       port,
+                       LT(" exceeds maximum allowed."));
+              transfer_handler(asio::error::fault, transferred);
+            }
+            else {
+              asio::async_read(
+                  socket,
+                  asio::buffer(data, size_header),
+                  asio::transfer_exactly(size_header),
+                  boost::bind(&Rpc::transfer_handler,
+                              this,
+                              asio::placeholders::error,
+                              asio::placeholders::bytes_transferred));
+            }
+          }
+          else {
+            transfer_handler(ec, transferred);
+          }
+        });
+
+    error_code = error_code_sync.await_error_code();
+
+    if (error_code)
+      throw runtime_error("Response read failed " + error_code.message());
+
+    string reply(data, data + size_header);
+
+    if (!error_code)
+      LOGFINE(LT("Received reply from  "),
+              ip_address,
+              LT(":"),
+              port,
+              LT(" - "),
+              reply);
+
+    return reply;
+  }
+
+  void Rpc::transfer_handler(const system::error_code& ec, size_t transferred) {
+    error_code_sync.signal_error_code(ec);
+  }
+} // namespace malmo
 
 #undef LOG_COMPONENT

--- a/external/malmo/Malmo/src/TimestampedVideoFrame.cpp
+++ b/external/malmo/Malmo/src/TimestampedVideoFrame.cpp
@@ -28,6 +28,8 @@
 // Boost:
 #include <boost/asio.hpp>
 
+using namespace std;
+
 namespace malmo {
   TimestampedVideoFrame::TimestampedVideoFrame()
       : width(0), height(0), channels(0), xPos(0), yPos(0), zPos(0), yaw(0),
@@ -58,12 +60,12 @@ namespace malmo {
     const int stride = width * channels;
     switch (transform) {
     case IDENTITY:
-      this->pixels = std::vector<unsigned char>(
+      this->pixels = vector<unsigned char>(
           message.data.begin() + FRAME_HEADER_SIZE, message.data.end());
       break;
 
     case RAW_BMP:
-      this->pixels = std::vector<unsigned char>(
+      this->pixels = vector<unsigned char>(
           message.data.begin() + FRAME_HEADER_SIZE, message.data.end());
       if (channels == 3) {
         // Swap BGR -> RGB:
@@ -76,7 +78,7 @@ namespace malmo {
       break;
 
     case REVERSE_SCANLINE:
-      this->pixels = std::vector<unsigned char>();
+      this->pixels = vector<unsigned char>();
       for (int i = 0, offset = (height - 1) * stride; i < height;
            i++, offset -= stride) {
         auto it = message.data.begin() + offset + FRAME_HEADER_SIZE;
@@ -86,7 +88,7 @@ namespace malmo {
       break;
 
     default:
-      throw std::invalid_argument("Unknown transform");
+      throw invalid_argument("Unknown transform");
     }
   }
 
@@ -99,8 +101,7 @@ namespace malmo {
     // comparison.
   }
 
-  std::ostream& operator<<(std::ostream& os,
-                           const TimestampedVideoFrame& tsvidframe) {
+  ostream& operator<<(ostream& os, const TimestampedVideoFrame& tsvidframe) {
     os << "TimestampedVideoFrame: " << to_simple_string(tsvidframe.timestamp)
        << ", type " << tsvidframe.frametype << ", " << tsvidframe.width << " x "
        << tsvidframe.height << " x " << tsvidframe.channels << ", ("
@@ -109,8 +110,8 @@ namespace malmo {
     return os;
   }
 
-  std::ostream& operator<<(std::ostream& os,
-                           const TimestampedVideoFrame::FrameType& type) {
+  ostream& operator<<(ostream& os,
+                      const TimestampedVideoFrame::FrameType& type) {
     switch (type) {
     case TimestampedVideoFrame::VIDEO:
       os << "video";

--- a/external/malmo/Malmo/src/TimestampedVideoFrame.cpp
+++ b/external/malmo/Malmo/src/TimestampedVideoFrame.cpp
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
@@ -25,109 +28,112 @@
 // Boost:
 #include <boost/asio.hpp>
 
-namespace malmo
-{
-    TimestampedVideoFrame::TimestampedVideoFrame()
-        : width(0)
-        , height(0)
-        , channels(0)
-        , xPos(0)
-        , yPos(0)
-        , zPos(0)
-        , yaw(0)
-        , pitch(0)
-        , frametype(VIDEO)
-    {
+namespace malmo {
+  TimestampedVideoFrame::TimestampedVideoFrame()
+      : width(0), height(0), channels(0), xPos(0), yPos(0), zPos(0), yaw(0),
+        pitch(0), frametype(VIDEO) {}
 
-    }
+  TimestampedVideoFrame::TimestampedVideoFrame(
+      short width,
+      short height,
+      short channels,
+      TimestampedUnsignedCharVector& message,
+      Transform transform,
+      FrameType frametype)
+      : timestamp(message.timestamp), width(width), height(height),
+        channels(channels), frametype(frametype), xPos(0), yPos(0), zPos(0),
+        yaw(0), pitch(0) {
+    // First extract the positional information from the header:
+    uint32_t* pInt = reinterpret_cast<uint32_t*>(&(message.data[0]));
+    this->xPos = ntoh_float(*pInt);
+    pInt++;
+    this->yPos = ntoh_float(*pInt);
+    pInt++;
+    this->zPos = ntoh_float(*pInt);
+    pInt++;
+    this->yaw = ntoh_float(*pInt);
+    pInt++;
+    this->pitch = ntoh_float(*pInt);
 
-    TimestampedVideoFrame::TimestampedVideoFrame(short width, short height, short channels, TimestampedUnsignedCharVector& message, Transform transform, FrameType frametype)
-        : timestamp(message.timestamp)
-        , width(width)
-        , height(height)
-        , channels(channels)
-        , frametype(frametype)
-        , xPos(0)
-        , yPos(0)
-        , zPos(0)
-        , yaw(0)
-        , pitch(0)
-    {
-        // First extract the positional information from the header:
-        uint32_t * pInt = reinterpret_cast<uint32_t*>(&(message.data[0]));
-        this->xPos = ntoh_float(*pInt); pInt++;
-        this->yPos = ntoh_float(*pInt); pInt++;
-        this->zPos = ntoh_float(*pInt); pInt++;
-        this->yaw = ntoh_float(*pInt); pInt++;
-        this->pitch = ntoh_float(*pInt);
+    const int stride = width * channels;
+    switch (transform) {
+    case IDENTITY:
+      this->pixels = std::vector<unsigned char>(
+          message.data.begin() + FRAME_HEADER_SIZE, message.data.end());
+      break;
 
-        const int stride = width * channels;
-        switch (transform){
-        case IDENTITY:
-            this->pixels = std::vector<unsigned char>(message.data.begin() + FRAME_HEADER_SIZE, message.data.end());
-            break;
-
-        case RAW_BMP:
-            this->pixels = std::vector<unsigned char>(message.data.begin() + FRAME_HEADER_SIZE, message.data.end());
-            if (channels == 3){
-                // Swap BGR -> RGB:
-                for (int i = 0; i < this->pixels.size(); i += 3){
-                    char t = this->pixels[i];
-                    this->pixels[i] = this->pixels[i + 2];
-                    this->pixels[i + 2] = t;
-                }
-            }
-            break;
-
-        case REVERSE_SCANLINE:
-            this->pixels = std::vector<unsigned char>();
-            for (int i = 0, offset = (height - 1)*stride; i < height; i++, offset -= stride){
-                auto it = message.data.begin() + offset + FRAME_HEADER_SIZE;
-                this->pixels.insert(this->pixels.end(), it, it + stride);
-            }
-
-            break;
-
-        default:
-            throw std::invalid_argument("Unknown transform");
+    case RAW_BMP:
+      this->pixels = std::vector<unsigned char>(
+          message.data.begin() + FRAME_HEADER_SIZE, message.data.end());
+      if (channels == 3) {
+        // Swap BGR -> RGB:
+        for (int i = 0; i < this->pixels.size(); i += 3) {
+          char t = this->pixels[i];
+          this->pixels[i] = this->pixels[i + 2];
+          this->pixels[i + 2] = t;
         }
-    }
+      }
+      break;
 
-    bool TimestampedVideoFrame::operator==(const TimestampedVideoFrame& other) const
-    {
-        return this->frametype == other.frametype && this->width == other.width && this->height == other.height && this->channels == other.channels && this->timestamp == other.timestamp && this->pixels == other.pixels;
-        // Not much point in comparing pos, pitch and yaw - covered by the pixel comparison.
-    }
+    case REVERSE_SCANLINE:
+      this->pixels = std::vector<unsigned char>();
+      for (int i = 0, offset = (height - 1) * stride; i < height;
+           i++, offset -= stride) {
+        auto it = message.data.begin() + offset + FRAME_HEADER_SIZE;
+        this->pixels.insert(this->pixels.end(), it, it + stride);
+      }
 
-    std::ostream& operator<<(std::ostream& os, const TimestampedVideoFrame& tsvidframe)
-    {
-        os << "TimestampedVideoFrame: " << to_simple_string(tsvidframe.timestamp) << ", type " << tsvidframe.frametype << ", " << tsvidframe.width << " x " << tsvidframe.height << " x " << tsvidframe.channels << ", (" << tsvidframe.xPos << "," << tsvidframe.yPos << "," << tsvidframe.zPos << " - yaw:" << tsvidframe.yaw << ", pitch:" << tsvidframe.pitch << ")";
-        return os;
-    }
+      break;
 
-    std::ostream& operator<<(std::ostream& os, const TimestampedVideoFrame::FrameType& type)
-    {
-        switch (type)
-        {
-        case TimestampedVideoFrame::VIDEO:
-            os << "video"; break;
-        case TimestampedVideoFrame::DEPTH_MAP:
-            os << "depth"; break;
-        case TimestampedVideoFrame::LUMINANCE:
-            os << "luminance"; break;
-        case TimestampedVideoFrame::COLOUR_MAP:
-            os << "colourmap"; break;
-        default:
-            break;
-        }
-        return os;
+    default:
+      throw std::invalid_argument("Unknown transform");
     }
+  }
 
-    float TimestampedVideoFrame::ntoh_float(uint32_t value) const
-    {
-        uint32_t temp = ntohl(value);
-        float ret;
-        *((uint32_t*)&ret) = temp;
-        return ret;
+  bool
+  TimestampedVideoFrame::operator==(const TimestampedVideoFrame& other) const {
+    return this->frametype == other.frametype && this->width == other.width &&
+           this->height == other.height && this->channels == other.channels &&
+           this->timestamp == other.timestamp && this->pixels == other.pixels;
+    // Not much point in comparing pos, pitch and yaw - covered by the pixel
+    // comparison.
+  }
+
+  std::ostream& operator<<(std::ostream& os,
+                           const TimestampedVideoFrame& tsvidframe) {
+    os << "TimestampedVideoFrame: " << to_simple_string(tsvidframe.timestamp)
+       << ", type " << tsvidframe.frametype << ", " << tsvidframe.width << " x "
+       << tsvidframe.height << " x " << tsvidframe.channels << ", ("
+       << tsvidframe.xPos << "," << tsvidframe.yPos << "," << tsvidframe.zPos
+       << " - yaw:" << tsvidframe.yaw << ", pitch:" << tsvidframe.pitch << ")";
+    return os;
+  }
+
+  std::ostream& operator<<(std::ostream& os,
+                           const TimestampedVideoFrame::FrameType& type) {
+    switch (type) {
+    case TimestampedVideoFrame::VIDEO:
+      os << "video";
+      break;
+    case TimestampedVideoFrame::DEPTH_MAP:
+      os << "depth";
+      break;
+    case TimestampedVideoFrame::LUMINANCE:
+      os << "luminance";
+      break;
+    case TimestampedVideoFrame::COLOUR_MAP:
+      os << "colourmap";
+      break;
+    default:
+      break;
     }
-}
+    return os;
+  }
+
+  float TimestampedVideoFrame::ntoh_float(uint32_t value) const {
+    uint32_t temp = ntohl(value);
+    float ret;
+    *((uint32_t*)&ret) = temp;
+    return ret;
+  }
+} // namespace malmo

--- a/external/malmo/Malmo/src/TimestampedVideoFrame.h
+++ b/external/malmo/Malmo/src/TimestampedVideoFrame.h
@@ -1,24 +1,26 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _TIMESTAMPEDVIDEOFRAME_H_
-#define _TIMESTAMPEDVIDEOFRAME_H_
+#pragma once
 
 // Local:
 #include "TimestampedUnsignedCharVector.h"
@@ -29,67 +31,78 @@
 // STL:
 #include <vector>
 
-namespace malmo 
-{
-    //! An image with an attached timestamp saying when it was collected.
-    struct TimestampedVideoFrame 
-    {
-        enum Transform {
-            IDENTITY                //!< Don't alter the incoming bytes in any way
-            , RAW_BMP               //!< Layout bytes as raw BMP data (bottom-to-top RGB)
-            , REVERSE_SCANLINE      //!< Interpret input bytes as reverse scanline BGR
-        };
-        enum FrameType {
-            _MIN_FRAME_TYPE = 0
-            , VIDEO = _MIN_FRAME_TYPE //!< Normal video, either 24bpp RGB or 32bpp RGBD
-            , DEPTH_MAP               //!< 32bpp float depthmap
-            , LUMINANCE               //!< 8bpp greyscale bitmap
-            , COLOUR_MAP              //!< 24bpp colour map
-            , _MAX_FRAME_TYPE
-        };
-        static const int FRAME_HEADER_SIZE = 20;
-
-        //! The timestamp.
-        boost::posix_time::ptime timestamp;
-        
-        //! The width of the image in pixels.
-        short width;
-        
-        //! The height of the image in pixels.
-        short height;
-        
-        //! The number of channels. e.g. 3 for RGB data, 4 for RGBD
-        short channels;
-
-        //! The type of video data - eg 24bpp RGB, or 32bpp float depth
-        FrameType frametype;
-
-        //! The pitch of the player at render time
-        float pitch;
-
-        //! The yaw of the player at render time
-        float yaw;
-
-        //! The x pos of the player at render time
-        float xPos;
-
-        //! The y pos of the player at render time
-        float yPos;
-
-        //! The z pos of the player at render time
-        float zPos;
-
-        //! The pixels, stored as channels then columns then rows. Length should be width*height*channels.
-        std::vector<unsigned char> pixels;
-
-        TimestampedVideoFrame();
-        TimestampedVideoFrame(short width, short height, short channels, TimestampedUnsignedCharVector& message, Transform transform = IDENTITY, FrameType frametype = VIDEO);
-        
-        bool operator==(const TimestampedVideoFrame& other) const;
-        friend std::ostream& operator<<(std::ostream& os, const TimestampedVideoFrame& tsvidframe);
-        friend std::ostream& operator<<(std::ostream& os, const TimestampedVideoFrame::FrameType& frametype);
-        float ntoh_float(uint32_t value) const;
+namespace malmo {
+  //! An image with an attached timestamp saying when it was collected.
+  struct TimestampedVideoFrame {
+    enum Transform {
+      IDENTITY //!< Don't alter the incoming bytes in any way
+      ,
+      RAW_BMP //!< Layout bytes as raw BMP data (bottom-to-top RGB)
+      ,
+      REVERSE_SCANLINE //!< Interpret input bytes as reverse scanline BGR
     };
-}
+    enum FrameType {
+      _MIN_FRAME_TYPE = 0,
+      VIDEO = _MIN_FRAME_TYPE //!< Normal video, either 24bpp RGB or 32bpp RGBD
+      ,
+      DEPTH_MAP //!< 32bpp float depthmap
+      ,
+      LUMINANCE //!< 8bpp greyscale bitmap
+      ,
+      COLOUR_MAP //!< 24bpp colour map
+      ,
+      _MAX_FRAME_TYPE
+    };
+    static const int FRAME_HEADER_SIZE = 20;
 
-#endif
+    //! The timestamp.
+    boost::posix_time::ptime timestamp;
+
+    //! The width of the image in pixels.
+    short width;
+
+    //! The height of the image in pixels.
+    short height;
+
+    //! The number of channels. e.g. 3 for RGB data, 4 for RGBD
+    short channels;
+
+    //! The type of video data - eg 24bpp RGB, or 32bpp float depth
+    FrameType frametype;
+
+    //! The pitch of the player at render time
+    float pitch;
+
+    //! The yaw of the player at render time
+    float yaw;
+
+    //! The x pos of the player at render time
+    float xPos;
+
+    //! The y pos of the player at render time
+    float yPos;
+
+    //! The z pos of the player at render time
+    float zPos;
+
+    //! The pixels, stored as channels then columns then rows. Length should be
+    //! width*height*channels.
+    std::vector<unsigned char> pixels;
+
+    TimestampedVideoFrame();
+    TimestampedVideoFrame(short width,
+                          short height,
+                          short channels,
+                          TimestampedUnsignedCharVector& message,
+                          Transform transform = IDENTITY,
+                          FrameType frametype = VIDEO);
+
+    bool operator==(const TimestampedVideoFrame& other) const;
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const TimestampedVideoFrame& tsvidframe);
+    friend std::ostream&
+    operator<<(std::ostream& os,
+               const TimestampedVideoFrame::FrameType& frametype);
+    float ntoh_float(uint32_t value) const;
+  };
+} // namespace malmo

--- a/external/malmo/Malmo/src/VideoFrameWriter.cpp
+++ b/external/malmo/Malmo/src/VideoFrameWriter.cpp
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
@@ -33,251 +36,291 @@
 
 #define LOG_COMPONENT Logger::LOG_VIDEO
 
-namespace malmo
-{
-    VideoFrameWriter::VideoFrameWriter(std::string path, std::string frame_info_filename, short width, short height, int frames_per_second, int channels, bool drop_input_frames)
-        : path(path)
-        , width(width)
-        , height(height)
-        , frames_per_second(frames_per_second)
-        , drop_input_frames(drop_input_frames)
-        , channels(channels)
-        , is_open(false)
-        , frame_duration(boost::posix_time::milliseconds(1000) / frames_per_second)
-    {
-        boost::filesystem::path fs_path(path);
-        if (boost::filesystem::is_directory(fs_path)) {
-            this->frame_info_path = fs_path / frame_info_filename;
+using namespace std;
+namespace fs = boost::filesystem;
+
+namespace malmo {
+  VideoFrameWriter::VideoFrameWriter(string path,
+                                     string frame_info_filename,
+                                     short width,
+                                     short height,
+                                     int frames_per_second,
+                                     int channels,
+                                     bool drop_input_frames)
+      : path(path), width(width), height(height),
+        frames_per_second(frames_per_second),
+        drop_input_frames(drop_input_frames), channels(channels),
+        is_open(false), frame_duration(boost::posix_time::milliseconds(1000) /
+                                       frames_per_second) {
+    fs::path fs_path(path);
+    if (fs::is_directory(fs_path)) {
+      this->frame_info_path = fs_path / frame_info_filename;
+    }
+    else {
+      this->frame_info_path = fs_path.parent_path() / frame_info_filename;
+    }
+  }
+
+  VideoFrameWriter::~VideoFrameWriter() { this->close(); }
+
+  void VideoFrameWriter::open() {
+    this->close();
+
+    // Create helpful script:
+    fs::path fs_path(this->path);
+    string ffmpeg_helpfile =
+        (fs_path.parent_path() / (fs_path.stem().string() + "_to_pngs.sh"))
+            .string();
+    ofstream helpfile(ffmpeg_helpfile);
+    helpfile << "#! To extract individual frames from the mp4\n";
+    helpfile << "mkdir " << fs_path.stem().string() << "_frames\n";
+    helpfile << "ffmpeg -i " << fs_path.filename() << " "
+             << fs_path.stem().string() << "_frames/frame_%06d.png\n";
+
+    this->frame_info_stream.open(this->frame_info_path.string());
+
+    this->frame_info_stream << "width=" << this->width << endl;
+    this->frame_info_stream << "height=" << this->height << endl;
+
+    this->is_open = true;
+
+    this->start_time = boost::posix_time::microsec_clock::universal_time();
+    this->last_timestamp = this->start_time - this->frame_duration;
+
+    this->frame_index = 0;
+
+    this->frames_available = false;
+    this->frame_writer_thread =
+        boost::thread(&VideoFrameWriter::writeFrames, this);
+  }
+
+  bool VideoFrameWriter::isOpen() const { return this->is_open; }
+
+  void VideoFrameWriter::close() {
+    LOGSECTION(LOG_FINE, "In VideoFrameWriter::close()...");
+    if (this->is_open) {
+      this->frame_info_stream.close();
+
+      this->is_open = false;
+      LOGFINE(LT("Set is_open to false"));
+      {
+        boost::lock_guard<boost::mutex> frames_available_guard(
+            this->frames_available_mutex);
+
+        this->frames_available = true;
+      }
+
+      LOGFINE(LT("Notifying worker thread that frames are available, in order "
+                 "to close."));
+      this->frames_available_cond.notify_one();
+      LOGFINE(LT("Waiting for worker thread to join."));
+      this->frame_writer_thread.join();
+      LOGFINE(LT("Worker thread joined."));
+      LOGFINE(LT("Frames received for writing: "), this->frame_index);
+      LOGFINE(LT("Frames actually written: "), this->frames_actually_written);
+    }
+  }
+
+  void VideoFrameWriter::writeFrames() {
+    this->frames_actually_written = 0;
+    while (this->is_open) {
+      {
+        boost::unique_lock<boost::mutex> lock(this->frames_available_mutex);
+
+        while (!this->frames_available) {
+          this->frames_available_cond.wait(lock);
         }
-        else {
-            this->frame_info_path = fs_path.parent_path() / frame_info_filename;
-        }
-    }
+      }
 
-    VideoFrameWriter::~VideoFrameWriter()
-    {
-        this->close();
-    }
-
-    void VideoFrameWriter::open()
-    {
-        this->close();
-
-        // Create helpful script:
-        boost::filesystem::path fs_path(this->path);
-        std::string ffmpeg_helpfile = (fs_path.parent_path() / (fs_path.stem().string() + "_to_pngs.sh")).string();
-        std::ofstream helpfile(ffmpeg_helpfile);
-        helpfile << "#! To extract individual frames from the mp4\n";
-        helpfile << "mkdir " << fs_path.stem().string() << "_frames\n";
-        helpfile << "ffmpeg -i " << fs_path.filename() << " " << fs_path.stem().string() << "_frames/frame_%06d.png\n";
-
-        this->frame_info_stream.open(this->frame_info_path.string());
-
-        this->frame_info_stream << "width=" << this->width << std::endl;
-        this->frame_info_stream << "height=" << this->height << std::endl;
-
-        this->is_open = true;
-
-        this->start_time = boost::posix_time::microsec_clock::universal_time();
-        this->last_timestamp = this->start_time - this->frame_duration;
-
-        this->frame_index = 0;
-
-        this->frames_available = false;
-        this->frame_writer_thread = boost::thread(&VideoFrameWriter::writeFrames, this);
-    }
-
-    bool VideoFrameWriter::isOpen() const
-    {
-        return this->is_open;
-    }
-
-    void VideoFrameWriter::close()
-    {
-        LOGSECTION(LOG_FINE, "In VideoFrameWriter::close()...");
-        if (this->is_open) {
-            this->frame_info_stream.close();
-
-            this->is_open = false;
-            LOGFINE(LT("Set is_open to false"));
-            {
-                boost::lock_guard<boost::mutex> frames_available_guard(this->frames_available_mutex);
-
-                this->frames_available = true;
-            }
-
-            LOGFINE(LT("Notifying worker thread that frames are available, in order to close."));
-            this->frames_available_cond.notify_one();
-            LOGFINE(LT("Waiting for worker thread to join."));
-            this->frame_writer_thread.join();
-            LOGFINE(LT("Worker thread joined."));
-            LOGFINE(LT("Frames received for writing: "), this->frame_index);
-            LOGFINE(LT("Frames actually written: "), this->frames_actually_written);
-        }
-    }
-
-    void VideoFrameWriter::writeFrames()
-    {
-        this->frames_actually_written = 0;
-        while (this->is_open) {
-            {
-                boost::unique_lock<boost::mutex> lock(this->frames_available_mutex);
-
-                while (!this->frames_available) {
-                    this->frames_available_cond.wait(lock);
-                }
-            }
-
-            while (true) {
-                TimestampedVideoFrame frame;
-                {
-                    boost::lock_guard<boost::mutex> buffer_guard(this->frame_buffer_mutex);
-
-                    if (this->frame_buffer.size() > 0) {
-                        frame = this->frame_buffer.front();
-                        this->frame_buffer.pop();
-                    }
-                }
-
-                if (frame.width == 0) {
-                    boost::lock_guard<boost::mutex> frames_available_guard(this->frames_available_mutex);
-
-                    this->frames_available = false;
-                    break;
-                }
-
-                try
-                {
-                    writeSingleFrame(frame, this->frames_actually_written);
-                    this->frames_actually_written++;
-                }
-                catch (std::exception& e)
-                {
-                    LOGERROR(LT("Failed to write frame: "), e.what());
-                }
-            }
-        }
-    }
-
-    void VideoFrameWriter::writeSingleFrame(const TimestampedVideoFrame& frame, int count)
-    {
-        LOGTRACE(LT("Writing frame "), count + 1, LT(", "), frame.width, LT("x"), frame.height, LT("x"), frame.channels);
-        if (frame.channels == 4)
+      while (true) {
+        TimestampedVideoFrame frame;
         {
-            if (frame.frametype == TimestampedVideoFrame::DEPTH_MAP)
-            {
-                // For making videos out of 32bpp depth maps, what exactly should we display?
-                // We could reduce to greyscale, but that way we loose a lot of precision.
-                // Instead, convert to an HSV colour cone, which hopefully gives a greater range
-                // of colour values to map to.
-                const float* fPixels = reinterpret_cast<const float*>(&(frame.pixels[0]));
-                char *out_pixels = new char[frame.width * frame.height * 3];
-                for (int i = 0; i < frame.width*frame.height; i++)
-                {
-                    float f = fPixels[i];
-                    float h = 60.0f * f;
-                    while (h >= 360.0)
-                        h -= 360.0;
-                    float s = 1.0;
-                    float v = 1.0f - (f / 200.0f);
-                    if (v < 0)
-                        v = 0;
-                    if (v > 1.0)
-                        v = 1.0;
-                    h = h / 60.0f;
-                    float fract = h - floor(h);
+          boost::lock_guard<boost::mutex> buffer_guard(
+              this->frame_buffer_mutex);
 
-                    v *= 255.0;
-
-                    float p = v*(1.0f - s);
-                    float q = v*(1.0f - s*fract);
-                    float t = v*(1.0f - s*(1.0f - fract));
-
-                    unsigned int out;
-                    if (0. <= h && h < 1.)
-                        out = int(v) + (int(t) << 8) + (int(p) << 16);
-                    else if (1. <= h && h < 2.)
-                        out = int(q) + (int(v) << 8) + (int(p) << 16);
-                    else if (2. <= h && h < 3.)
-                        out = int(p) + (int(v) << 8) + (int(t) << 16);
-                    else if (3. <= h && h < 4.)
-                        out = int(p) + (int(q) << 8) + (int(v) << 16);
-                    else if (4. <= h && h < 5.)
-                        out = int(t) + (int(p) << 8) + (int(v) << 16);
-                    else if (5. <= h && h < 6.)
-                        out = int(v) + (int(p) << 8) + (int(q) << 16);
-                    else
-                        out = 0;
-
-                    out_pixels[3 * i] = out & 0xff;
-                    out_pixels[3 * i + 1] = (out >> 8) & 0xff;
-                    out_pixels[3 * i + 2] = (out >> 16) & 0xff;
-                }
-                this->doWrite(out_pixels, frame.width, frame.height, count);
-                delete[] out_pixels;
-            }
-            else
-            {
-                // extract DDD from RGBD
-                char *out_pixels = new char[frame.width * frame.height * 3];
-                for (int i = 0; i < frame.width*frame.height; i++)
-                {
-                    out_pixels[i * 3] = out_pixels[i * 3 + 1] = out_pixels[i * 3 + 2] = frame.pixels[i * 4 + 3];
-                }
-                this->doWrite(out_pixels, frame.width, frame.height, count);
-                delete[] out_pixels;
-            }
+          if (this->frame_buffer.size() > 0) {
+            frame = this->frame_buffer.front();
+            this->frame_buffer.pop();
+          }
         }
-        else if (frame.channels == 3 || frame.channels == 1)
-        {
-            // write the pixel data directly
-            this->doWrite((char*)&frame.pixels[0], frame.width, frame.height, count);
+
+        if (frame.width == 0) {
+          boost::lock_guard<boost::mutex> frames_available_guard(
+              this->frames_available_mutex);
+
+          this->frames_available = false;
+          break;
         }
-        else throw std::runtime_error("Unsupported number of channels");
+
+        try {
+          writeSingleFrame(frame, this->frames_actually_written);
+          this->frames_actually_written++;
+        }
+        catch (exception& e) {
+          LOGERROR(LT("Failed to write frame: "), e.what());
+        }
+      }
     }
+  }
 
-    bool VideoFrameWriter::write(TimestampedVideoFrame frame)
-    {
-        boost::lock_guard<boost::mutex> write_guard(this->write_mutex);
+  void VideoFrameWriter::writeSingleFrame(const TimestampedVideoFrame& frame,
+                                          int count) {
+    LOGTRACE(LT("Writing frame "),
+             count + 1,
+             LT(", "),
+             frame.width,
+             LT("x"),
+             frame.height,
+             LT("x"),
+             frame.channels);
+    if (frame.channels == 4) {
+      if (frame.frametype == TimestampedVideoFrame::DEPTH_MAP) {
+        // For making videos out of 32bpp depth maps, what exactly should we
+        // display? We could reduce to greyscale, but that way we lose a lot of
+        // precision. Instead, convert to an HSV colour cone, which hopefully
+        // gives a greater range of colour values to map to.
+        const float* fPixels =
+            reinterpret_cast<const float*>(&(frame.pixels[0]));
+        char* out_pixels = new char[frame.width * frame.height * 3];
+        for (int i = 0; i < frame.width * frame.height; i++) {
+          float f = fPixels[i];
+          float h = 60.0f * f;
+          while (h >= 360.0)
+            h -= 360.0;
+          float s = 1.0;
+          float v = 1.0f - (f / 200.0f);
+          if (v < 0)
+            v = 0;
+          if (v > 1.0)
+            v = 1.0;
+          h = h / 60.0f;
+          float fract = h - floor(h);
 
-        if (!this->drop_input_frames || frame.timestamp - this->last_timestamp >= this->frame_duration) {
-            this->last_timestamp = frame.timestamp;
+          v *= 255.0;
 
-            std::stringstream name;
-            name << "frame_" << std::setfill('0') << std::setw(6) << this->frame_index + 1;
-            std::stringstream posdata;
-            posdata << "xyzyp: " << frame.xPos << " " << frame.yPos << " " << frame.zPos << " " << frame.yaw << " " << frame.pitch;
-            this->frame_info_stream << boost::posix_time::to_iso_string(frame.timestamp) << " " << name.str() << " " << posdata.str() << std::endl;
+          float p = v * (1.0f - s);
+          float q = v * (1.0f - s * fract);
+          float t = v * (1.0f - s * (1.0f - fract));
 
-            this->frame_index++;
-            {
-                boost::lock_guard<boost::mutex> buffer_guard(this->frame_buffer_mutex);
+          unsigned int out;
+          if (0. <= h && h < 1.)
+            out = int(v) + (int(t) << 8) + (int(p) << 16);
+          else if (1. <= h && h < 2.)
+            out = int(q) + (int(v) << 8) + (int(p) << 16);
+          else if (2. <= h && h < 3.)
+            out = int(p) + (int(v) << 8) + (int(t) << 16);
+          else if (3. <= h && h < 4.)
+            out = int(p) + (int(q) << 8) + (int(v) << 16);
+          else if (4. <= h && h < 5.)
+            out = int(t) + (int(p) << 8) + (int(v) << 16);
+          else if (5. <= h && h < 6.)
+            out = int(v) + (int(p) << 8) + (int(q) << 16);
+          else
+            out = 0;
 
-                LOGTRACE(LT("Pushing frame "), this->frame_index, LT(", "), frame.width, LT("x"), frame.height, LT("x"), frame.channels, LT(" to write buffer."));
-                this->frame_buffer.push(frame);
-            }
-
-            {
-                boost::lock_guard<boost::mutex> frames_available_guard(this->frames_available_mutex);
-
-                this->frames_available = true;
-            }
-
-            this->frames_available_cond.notify_one();
-            return true;
+          out_pixels[3 * i] = out & 0xff;
+          out_pixels[3 * i + 1] = (out >> 8) & 0xff;
+          out_pixels[3 * i + 2] = (out >> 16) & 0xff;
         }
-        return false;
+        this->doWrite(out_pixels, frame.width, frame.height, count);
+        delete[] out_pixels;
+      }
+      else {
+        // extract DDD from RGBD
+        char* out_pixels = new char[frame.width * frame.height * 3];
+        for (int i = 0; i < frame.width * frame.height; i++) {
+          out_pixels[i * 3] = out_pixels[i * 3 + 1] = out_pixels[i * 3 + 2] =
+              frame.pixels[i * 4 + 3];
+        }
+        this->doWrite(out_pixels, frame.width, frame.height, count);
+        delete[] out_pixels;
+      }
     }
+    else if (frame.channels == 3 || frame.channels == 1) {
+      // write the pixel data directly
+      this->doWrite((char*)&frame.pixels[0], frame.width, frame.height, count);
+    }
+    else
+      throw runtime_error("Unsupported number of channels");
+  }
 
-    std::unique_ptr<VideoFrameWriter> VideoFrameWriter::create(std::string path, std::string info_filename, short width, short height, int frames_per_second, int64_t bit_rate, int channels, bool drop_input_frames)
-    {
+  bool VideoFrameWriter::write(TimestampedVideoFrame frame) {
+    boost::lock_guard<boost::mutex> write_guard(this->write_mutex);
+
+    if (!this->drop_input_frames ||
+        frame.timestamp - this->last_timestamp >= this->frame_duration) {
+      this->last_timestamp = frame.timestamp;
+
+      stringstream name;
+      name << "frame_" << setfill('0') << setw(6) << this->frame_index + 1;
+      stringstream posdata;
+      posdata << "xyzyp: " << frame.xPos << " " << frame.yPos << " "
+              << frame.zPos << " " << frame.yaw << " " << frame.pitch;
+      this->frame_info_stream
+          << boost::posix_time::to_iso_string(frame.timestamp) << " "
+          << name.str() << " " << posdata.str() << endl;
+
+      this->frame_index++;
+      {
+        boost::lock_guard<boost::mutex> buffer_guard(this->frame_buffer_mutex);
+
+        LOGTRACE(LT("Pushing frame "),
+                 this->frame_index,
+                 LT(", "),
+                 frame.width,
+                 LT("x"),
+                 frame.height,
+                 LT("x"),
+                 frame.channels,
+                 LT(" to write buffer."));
+        this->frame_buffer.push(frame);
+      }
+
+      {
+        boost::lock_guard<boost::mutex> frames_available_guard(
+            this->frames_available_mutex);
+
+        this->frames_available = true;
+      }
+
+      this->frames_available_cond.notify_one();
+      return true;
+    }
+    return false;
+  }
+
+  unique_ptr<VideoFrameWriter>
+  VideoFrameWriter::create(string path,
+                           string info_filename,
+                           short width,
+                           short height,
+                           int frames_per_second,
+                           int64_t bit_rate,
+                           int channels,
+                           bool drop_input_frames) {
 #if WIN32
-        std::unique_ptr<VideoFrameWriter> instance( new WindowsFrameWriter(path, info_filename, width, height, frames_per_second, bit_rate, channels, drop_input_frames) );
+    unique_ptr<VideoFrameWriter> instance(
+        new WindowsFrameWriter(path,
+                               info_filename,
+                               width,
+                               height,
+                               frames_per_second,
+                               bit_rate,
+                               channels,
+                               drop_input_frames));
 #else
-        std::unique_ptr<VideoFrameWriter> instance( new PosixFrameWriter(path, info_filename, width, height, frames_per_second, bit_rate, channels, drop_input_frames) );
+    unique_ptr<VideoFrameWriter> instance(
+        new PosixFrameWriter(path,
+                             info_filename,
+                             width,
+                             height,
+                             frames_per_second,
+                             bit_rate,
+                             channels,
+                             drop_input_frames));
 #endif
-        return instance;
-    }
-}
+    return instance;
+  }
+} // namespace malmo
 
 #undef LOG_COMPONENT

--- a/external/malmo/Malmo/src/VideoFrameWriter.cpp
+++ b/external/malmo/Malmo/src/VideoFrameWriter.cpp
@@ -66,7 +66,7 @@ namespace malmo {
   void VideoFrameWriter::open() {
     this->close();
 
-    // Create helpful script:
+    // Create helpful script to extract individual frames from the .mp4 file:
     fs::path fs_path(this->path);
     string ffmpeg_helpfile =
         (fs_path.parent_path() / (fs_path.stem().string() + "_to_pngs.sh"))

--- a/external/malmo/Malmo/src/VideoFrameWriter.h
+++ b/external/malmo/Malmo/src/VideoFrameWriter.h
@@ -1,24 +1,26 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _VIDEOFRAMEWRITER_H_
-#define _VIDEOFRAMEWRITER_H_
+#pragma once
 
 // Local:
 #include "TimestampedVideoFrame.h"
@@ -29,70 +31,80 @@
 #include <boost/thread.hpp>
 
 // STL:
-#include <string>
 #include <fstream>
 #include <iostream>
 #include <queue>
+#include <string>
 
-namespace malmo
-{
-    class IFrameWriter
-    {
-    public:
-        IFrameWriter() {}
-        virtual ~IFrameWriter() {}
-        virtual void open() = 0;
-        virtual void close() = 0;
-        virtual bool write(TimestampedVideoFrame frame) = 0;
-        virtual bool isOpen() const = 0;
-        virtual size_t getFrameWriteCount() const = 0;
-    };
+namespace malmo {
+  class IFrameWriter {
+  public:
+    IFrameWriter() {}
+    virtual ~IFrameWriter() {}
+    virtual void open() = 0;
+    virtual void close() = 0;
+    virtual bool write(TimestampedVideoFrame frame) = 0;
+    virtual bool isOpen() const = 0;
+    virtual size_t getFrameWriteCount() const = 0;
+  };
 
-    class VideoFrameWriter : public IFrameWriter
-    {
-    public:
-        VideoFrameWriter(std::string path, std::string info_filename, short width, short height, int frames_per_second, int channels, bool drop_input_frames);
-        virtual ~VideoFrameWriter();
-        virtual void open();
-        virtual void close();
-        
-        virtual bool write(TimestampedVideoFrame frame);
-        virtual bool isOpen() const;
-        virtual size_t getFrameWriteCount() const { return frames_actually_written; }
+  class VideoFrameWriter : public IFrameWriter {
+  public:
+    VideoFrameWriter(std::string path,
+                     std::string info_filename,
+                     short width,
+                     short height,
+                     int frames_per_second,
+                     int channels,
+                     bool drop_input_frames);
+    virtual ~VideoFrameWriter();
+    virtual void open();
+    virtual void close();
 
-        static std::unique_ptr<VideoFrameWriter> create(std::string path, std::string info_filename, short width, short height, int frames_per_second, int64_t bit_rate, int channels, bool drop_input_frames);
+    virtual bool write(TimestampedVideoFrame frame);
+    virtual bool isOpen() const;
+    virtual size_t getFrameWriteCount() const {
+      return frames_actually_written;
+    }
 
-    protected:
-        virtual void doWrite(char* rgb, int width, int height, int frame_index) = 0;
+    static std::unique_ptr<VideoFrameWriter> create(std::string path,
+                                                    std::string info_filename,
+                                                    short width,
+                                                    short height,
+                                                    int frames_per_second,
+                                                    int64_t bit_rate,
+                                                    int channels,
+                                                    bool drop_input_frames);
 
-        std::string path;
-        short width;
-        short height;
-        int frames_per_second;
-        bool drop_input_frames;
-        int channels;
-        bool is_open;
+  protected:
+    virtual void doWrite(char* rgb, int width, int height, int frame_index) = 0;
 
-    private:
-        void writeFrames();
-        void writeSingleFrame(const TimestampedVideoFrame& frame, int count);
+    std::string path;
+    short width;
+    short height;
+    int frames_per_second;
+    bool drop_input_frames;
+    int channels;
+    bool is_open;
 
-        boost::posix_time::ptime start_time;
-        boost::posix_time::ptime last_timestamp;
-        boost::posix_time::time_duration frame_duration;
-        std::ofstream frame_info_stream;
-        boost::filesystem::path frame_info_path;
-        int frame_index;
-        int frames_actually_written = 0;
+  private:
+    void writeFrames();
+    void writeSingleFrame(const TimestampedVideoFrame& frame, int count);
 
-        std::queue<TimestampedVideoFrame> frame_buffer;
-        boost::mutex write_mutex;
-        boost::mutex frame_buffer_mutex;
-        boost::mutex frames_available_mutex;
-        boost::condition_variable frames_available_cond;
-        bool frames_available;
-        boost::thread frame_writer_thread;
-    };
-}
+    boost::posix_time::ptime start_time;
+    boost::posix_time::ptime last_timestamp;
+    boost::posix_time::time_duration frame_duration;
+    std::ofstream frame_info_stream;
+    boost::filesystem::path frame_info_path;
+    int frame_index;
+    int frames_actually_written = 0;
 
-#endif
+    std::queue<TimestampedVideoFrame> frame_buffer;
+    boost::mutex write_mutex;
+    boost::mutex frame_buffer_mutex;
+    boost::mutex frames_available_mutex;
+    boost::condition_variable frames_available_cond;
+    bool frames_available;
+    boost::thread frame_writer_thread;
+  };
+} // namespace malmo

--- a/external/malmo/Malmo/src/VideoServer.cpp
+++ b/external/malmo/Malmo/src/VideoServer.cpp
@@ -29,6 +29,7 @@
 #include <boost/bind.hpp>
 
 using namespace std;
+namespace fs = boost::filesystem;
 
 namespace malmo {
   VideoServer::VideoServer(
@@ -136,8 +137,8 @@ namespace malmo {
       frame_dir = "video_frames";
       break;
     }
-    boost::filesystem::path fs_path(path);
-    boost::filesystem::path frame_path = fs_path / frame_dir;
+    fs::path fs_path(path);
+    fs::path frame_path = fs_path / frame_dir;
     this->writers.push_back(BmpFrameWriter::create(
         frame_path.string(),
         filename,

--- a/external/malmo/Malmo/src/VideoServer.cpp
+++ b/external/malmo/Malmo/src/VideoServer.cpp
@@ -1,184 +1,188 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 // Local:
 #include "VideoServer.h"
-#include "VideoFrameWriter.h"
 #include "BmpFrameWriter.h"
+#include "VideoFrameWriter.h"
 
 // Boost:
 #include <boost/bind.hpp>
 
-namespace malmo 
-{
-    VideoServer::VideoServer( boost::asio::io_service& io_service, int port, short width, short height, short channels, TimestampedVideoFrame::FrameType frametype, const boost::function<void(TimestampedVideoFrame message)> handle_frame )
-        : handle_frame( handle_frame )
-        , width( width )
-        , height( height )
-        , channels( channels )
-        , frametype( frametype )
-        , received_frames(0)
-        , written_frames(0)
-        , queued_frames(0)
-        , transform(TimestampedVideoFrame::REVERSE_SCANLINE)
-        , io_service(io_service)
-        , port(port)
-    {
-    }
+using namespace std;
 
-    // Start the server within a scope that is used to control sharing from async io calls.
-    void VideoServer::start(boost::shared_ptr<VideoServer>& scope)
-    {
-        this->server = boost::make_shared<TCPServer>(this->io_service, this->port, boost::bind(&VideoServer::handleMessage, scope, _1), "vid");
-        this->scope = scope;
-        this->written_frames = this->queued_frames = this->received_frames = 0;
-        this->server->start(scope.get());
-    }
-    
-    void VideoServer::close() {
-        this->server->close();
-    }
+namespace malmo {
+  VideoServer::VideoServer(
+      boost::asio::io_service& io_service,
+      int port,
+      short width,
+      short height,
+      short channels,
+      TimestampedVideoFrame::FrameType frametype,
+      const boost::function<void(TimestampedVideoFrame message)> handle_frame)
+      : handle_frame(handle_frame), width(width), height(height),
+        channels(channels), frametype(frametype), received_frames(0),
+        written_frames(0), queued_frames(0),
+        transform(TimestampedVideoFrame::REVERSE_SCANLINE),
+        io_service(io_service), port(port) {}
 
-    void VideoServer::release() {
-        this->scope = nullptr;
-    }
+  // Start the server within a scope that is used to control sharing from async
+  // io calls.
+  void VideoServer::start(boost::shared_ptr<VideoServer>& scope) {
+    this->server = boost::make_shared<TCPServer>(
+        this->io_service,
+        this->port,
+        boost::bind(&VideoServer::handleMessage, scope, _1),
+        "vid");
+    this->scope = scope;
+    this->written_frames = this->queued_frames = this->received_frames = 0;
+    this->server->start(scope.get());
+  }
 
-    void VideoServer::startRecording()
-    {
-        this->written_frames = this->queued_frames = this->received_frames = 0;
-        for (const auto& writer : this->writers){
-            writer->open();
+  void VideoServer::close() { this->server->close(); }
+
+  void VideoServer::release() { this->scope = nullptr; }
+
+  void VideoServer::startRecording() {
+    this->written_frames = this->queued_frames = this->received_frames = 0;
+    for (const auto& writer : this->writers) {
+      writer->open();
+    }
+  }
+
+  void VideoServer::stopRecording() {
+    for (const auto& writer : this->writers) {
+      if (writer->isOpen()) {
+        writer->close();
+        this->written_frames += writer->getFrameWriteCount();
+      }
+    }
+    this->writers.clear();
+  }
+
+  VideoServer& VideoServer::recordMP4(string path,
+                                      int frames_per_second,
+                                      int64_t bit_rate,
+                                      bool drop_input_frames) {
+    int channels = 3;
+    string filename;
+    switch (this->frametype) {
+    case TimestampedVideoFrame::COLOUR_MAP:
+      filename = "colour_map_info.txt";
+      break;
+    case TimestampedVideoFrame::DEPTH_MAP:
+      filename = "depth_frame_info.txt";
+      break;
+    case TimestampedVideoFrame::LUMINANCE:
+      filename = "luminance_frame_info.txt";
+      channels = 1;
+      break;
+    case TimestampedVideoFrame::VIDEO:
+    default:
+      filename = "frame_info.txt";
+      break;
+    }
+    this->writers.push_back(VideoFrameWriter::create(path,
+                                                     filename,
+                                                     this->width,
+                                                     this->height,
+                                                     frames_per_second,
+                                                     bit_rate,
+                                                     channels,
+                                                     drop_input_frames));
+    this->transform = TimestampedVideoFrame::REVERSE_SCANLINE;
+
+    return *this;
+  }
+
+  VideoServer& VideoServer::recordBmps(string path) {
+    string filename;
+    string frame_dir;
+    switch (this->frametype) {
+    case TimestampedVideoFrame::COLOUR_MAP:
+      filename = "colour_map_info.txt";
+      frame_dir = "colour_map_frames";
+      break;
+    case TimestampedVideoFrame::DEPTH_MAP:
+      filename = "depth_frame_info.txt";
+      frame_dir = "depth_frames";
+      break;
+    case TimestampedVideoFrame::LUMINANCE:
+      filename = "luminance_frame_info.txt";
+      frame_dir = "luminance_frames";
+      break;
+    case TimestampedVideoFrame::VIDEO:
+    default:
+      filename = "frame_info.txt";
+      frame_dir = "video_frames";
+      break;
+    }
+    boost::filesystem::path fs_path(path);
+    boost::filesystem::path frame_path = fs_path / frame_dir;
+    this->writers.push_back(BmpFrameWriter::create(
+        frame_path.string(),
+        filename,
+        this->frametype == TimestampedVideoFrame::DEPTH_MAP));
+    this->transform = TimestampedVideoFrame::REVERSE_SCANLINE;
+    return *this;
+  }
+
+  void VideoServer::handleMessage(TimestampedUnsignedCharVector message) {
+    if (message.data.size() !=
+        TimestampedVideoFrame::FRAME_HEADER_SIZE +
+            this->width * this->height * this->channels) {
+      // Have seen this happen during stress testing when a reward packet from
+      // (I think) a previous mission arrives during the next one when the same
+      // port has been reassigned. Could throw here but chose to silently ignore
+      // since very rare.
+      return;
+    }
+    TimestampedVideoFrame frame(this->width,
+                                this->height,
+                                this->channels,
+                                message,
+                                this->transform,
+                                this->frametype);
+    this->received_frames++;
+    this->handle_frame(frame);
+
+    for (const auto& writer : this->writers) {
+      if (writer->isOpen()) {
+        if (writer->write(frame)) {
+          this->queued_frames++;
         }
-    }   
-
-    void VideoServer::stopRecording()
-    {
-        for (const auto& writer : this->writers){
-            if (writer->isOpen()){
-                writer->close();
-                this->written_frames += writer->getFrameWriteCount();
-            }
-        }
-        this->writers.clear();
+      }
     }
+  }
 
-    VideoServer& VideoServer::recordMP4(std::string path, int frames_per_second, int64_t bit_rate, bool drop_input_frames)
-    {
-        int channels = 3;
-        std::string filename;
-        switch (this->frametype)
-        {
-        case TimestampedVideoFrame::COLOUR_MAP:
-            filename = "colour_map_info.txt";
-            break;
-        case TimestampedVideoFrame::DEPTH_MAP:
-            filename = "depth_frame_info.txt";
-            break;
-        case TimestampedVideoFrame::LUMINANCE:
-            filename = "luminance_frame_info.txt";
-            channels = 1;
-            break;
-        case TimestampedVideoFrame::VIDEO:
-        default:
-            filename = "frame_info.txt";
-            break;
-        }
-        this->writers.push_back(VideoFrameWriter::create(path, filename, this->width, this->height, frames_per_second, bit_rate, channels, drop_input_frames));
-        this->transform = TimestampedVideoFrame::REVERSE_SCANLINE;
+  int VideoServer::getPort() const { return this->server->getPort(); }
 
-        return *this;
-    }
+  short VideoServer::getWidth() const { return this->width; }
 
-    VideoServer& VideoServer::recordBmps(std::string path)
-    {
-        std::string filename;
-        std::string frame_dir;
-        switch (this->frametype)
-        {
-        case TimestampedVideoFrame::COLOUR_MAP:
-            filename = "colour_map_info.txt";
-            frame_dir = "colour_map_frames";
-            break;
-        case TimestampedVideoFrame::DEPTH_MAP:
-            filename = "depth_frame_info.txt";
-            frame_dir = "depth_frames";
-            break;
-        case TimestampedVideoFrame::LUMINANCE:
-            filename = "luminance_frame_info.txt";
-            frame_dir = "luminance_frames";
-            break;
-        case TimestampedVideoFrame::VIDEO:
-        default:
-            filename = "frame_info.txt";
-            frame_dir = "video_frames";
-            break;
-        }
-        boost::filesystem::path fs_path(path);
-        boost::filesystem::path frame_path = fs_path / frame_dir;
-        this->writers.push_back(BmpFrameWriter::create(frame_path.string(), filename, this->frametype==TimestampedVideoFrame::DEPTH_MAP));
-        this->transform = TimestampedVideoFrame::REVERSE_SCANLINE;
-        return *this;
-    }
+  short VideoServer::getHeight() const { return this->height; }
 
-    void VideoServer::handleMessage( TimestampedUnsignedCharVector message )
-    {
-        if (message.data.size() != TimestampedVideoFrame::FRAME_HEADER_SIZE + this->width * this->height * this->channels)
-        {
-            // Have seen this happen during stress testing when a reward packet from (I think) a previous mission arrives during the next
-            // one when the same port has been reassigned. Could throw here but chose to silently ignore since very rare.
-            return;
-        }
-        TimestampedVideoFrame frame(this->width, this->height, this->channels, message, this->transform, this->frametype);
-        this->received_frames++;
-        this->handle_frame(frame); 
+  short VideoServer::getChannels() const { return this->channels; }
 
-        for (const auto& writer : this->writers){
-            if (writer->isOpen()){
-                if (writer->write(frame)){
-                    this->queued_frames++;
-                }
-            }
-        }
-    }
-    
-    int VideoServer::getPort() const
-    {
-        return this->server->getPort();
-    }
-
-    short VideoServer::getWidth() const
-    {
-        return this->width;
-    }
-
-    short VideoServer::getHeight() const
-    {
-        return this->height;
-    }
-
-    short VideoServer::getChannels() const
-    {
-        return this->channels;
-    }
-
-    TimestampedVideoFrame::FrameType VideoServer::getFrameType() const
-    {
-        return this->frametype;
-    }
-}
+  TimestampedVideoFrame::FrameType VideoServer::getFrameType() const {
+    return this->frametype;
+  }
+} // namespace malmo

--- a/external/malmo/Malmo/src/VideoServer.h
+++ b/external/malmo/Malmo/src/VideoServer.h
@@ -1,24 +1,26 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
-#ifndef _VIDEOSERVER_H_
-#define _VIDEOSERVER_H_
+#pragma once
 
 // Local:
 #include "TCPServer.h"
@@ -30,81 +32,88 @@
 #include <boost/shared_ptr.hpp>
 
 // STL:
-#include <vector>
 #include <memory>
+#include <vector>
 
-namespace malmo
-{
-    //! A TCP server that receives video frames of a size specified beforehand and can optionally persist to file.
-    class VideoServer : ServerScope
-    {
-        public:
+namespace malmo {
+  //! A TCP server that receives video frames of a size specified beforehand and
+  //! can optionally persist to file.
+  class VideoServer : ServerScope {
+  public:
+    VideoServer(boost::asio::io_service& io_service,
+                int port,
+                short width,
+                short height,
+                short channels,
+                TimestampedVideoFrame::FrameType frametype,
+                const boost::function<void(const TimestampedVideoFrame message)>
+                    handle_frame);
 
-            VideoServer( boost::asio::io_service& io_service, int port, short width, short height, short channels, TimestampedVideoFrame::FrameType frametype, const boost::function<void(const TimestampedVideoFrame message)> handle_frame );
-            
-            //! Request that the video is saved in an mp4 file. Call before either startInBackground() or startRecording().
-            VideoServer& recordMP4(std::string path, int frames_per_second, int64_t bit_rate, bool drop_input_frames);
+    //! Request that the video is saved in an mp4 file. Call before either
+    //! startInBackground() or startRecording().
+    VideoServer& recordMP4(std::string path,
+                           int frames_per_second,
+                           int64_t bit_rate,
+                           bool drop_input_frames);
 
-            //! Request that each frame of the video is saved in an individual file. Call before either startInBackground() or startRecording().
-            VideoServer& recordBmps(std::string path);
+    //! Request that each frame of the video is saved in an individual file.
+    //! Call before either startInBackground() or startRecording().
+    VideoServer& recordBmps(std::string path);
 
-            //! Gets the port this server is listening on.
-            //! \returns The port this server is listening on.
-            int getPort() const;
-            
-            //! Gets the width of the video.
-            //! \returns The width of the video in pixels.
-            short getWidth() const;
-            
-            //! Gets the height of the video.
-            //! \returns The height of the video in pixels.
-            short getHeight() const;
-            
-            //! Gets the number of channels in the video. e.g. 3 for RGB, 4 for RGBA.
-            //! \returns The number of channels in the video.
-            short getChannels() const;
+    //! Gets the port this server is listening on.
+    //! \returns The port this server is listening on.
+    int getPort() const;
 
-            TimestampedVideoFrame::FrameType getFrameType() const;
+    //! Gets the width of the video.
+    //! \returns The width of the video in pixels.
+    short getWidth() const;
 
-            //! Stop recording the data being received by the server.
-            void stopRecording();
+    //! Gets the height of the video.
+    //! \returns The height of the video in pixels.
+    short getHeight() const;
 
-            //! Start recording the data being received by the server.
-            void startRecording();
+    //! Gets the number of channels in the video. e.g. 3 for RGB, 4 for RGBA.
+    //! \returns The number of channels in the video.
+    short getChannels() const;
 
-            //! Starts the video server.
-            void start(boost::shared_ptr<VideoServer>& scope);
+    TimestampedVideoFrame::FrameType getFrameType() const;
 
-            std::size_t receivedFrames() const { return this->received_frames; }
-            std::size_t writtenFrames() const { return this->written_frames; }
-            std::size_t queuedFrames() const { return this->queued_frames; }
+    //! Stop recording the data being received by the server.
+    void stopRecording();
 
-            void close();
+    //! Start recording the data being received by the server.
+    void startRecording();
 
-            virtual void release();
+    //! Starts the video server.
+    void start(boost::shared_ptr<VideoServer>& scope);
 
-        private:
+    std::size_t receivedFrames() const { return this->received_frames; }
+    std::size_t writtenFrames() const { return this->written_frames; }
+    std::size_t queuedFrames() const { return this->queued_frames; }
 
-            boost::shared_ptr<VideoServer> scope;
+    void close();
 
-            void handleMessage( const TimestampedUnsignedCharVector message );
-            
-            boost::function<void(const TimestampedVideoFrame message)> handle_frame;
-            short width;
-            short height;
-            short channels;
-            TimestampedVideoFrame::Transform transform;
-            TimestampedVideoFrame::FrameType frametype;
-            boost::shared_ptr<TCPServer> server;
-            boost::asio::io_service& io_service;
-            int port;
-            std::vector<std::unique_ptr<IFrameWriter>> writers;
+    virtual void release();
 
-            // diagnostics:
-            std::size_t received_frames;
-            std::size_t queued_frames;
-            std::size_t written_frames;
-    };
-}
+  private:
+    boost::shared_ptr<VideoServer> scope;
 
-#endif
+    void handleMessage(const TimestampedUnsignedCharVector message);
+
+    boost::function<void(const TimestampedVideoFrame message)> handle_frame;
+    short width;
+    short height;
+    short channels;
+    TimestampedVideoFrame::Transform transform;
+    TimestampedVideoFrame::FrameType frametype;
+    boost::shared_ptr<TCPServer> server;
+    boost::asio::io_service& io_service;
+    int port;
+    std::vector<std::unique_ptr<IFrameWriter>> writers;
+
+    // diagnostics:
+    std::size_t received_frames;
+    std::size_t queued_frames;
+    std::size_t written_frames;
+  };
+} // namespace malmo

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/VideoHook.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/VideoHook.java
@@ -1,31 +1,41 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 package com.microsoft.Malmo.Client;
 
+import com.microsoft.Malmo.MissionHandlerInterfaces.IVideoProducer;
+import com.microsoft.Malmo.MissionHandlerInterfaces.IVideoProducer.VideoType;
+import com.microsoft.Malmo.Schemas.ClientAgentConnection;
+import com.microsoft.Malmo.Schemas.MissionDiagnostics;
+import com.microsoft.Malmo.Schemas.MissionDiagnostics.VideoData;
+import com.microsoft.Malmo.Schemas.MissionInit;
+import com.microsoft.Malmo.Utils.AddressHelper;
+import com.microsoft.Malmo.Utils.TCPSocketChannel;
+import com.microsoft.Malmo.Utils.TextureHelper;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
-import com.microsoft.Malmo.Utils.AddressHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.launchwrapper.Launch;
@@ -34,21 +44,10 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
-
 import org.lwjgl.BufferUtils;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.DisplayMode;
-
-import com.microsoft.Malmo.MissionHandlerInterfaces.IVideoProducer;
-import com.microsoft.Malmo.MissionHandlerInterfaces.IVideoProducer.VideoType;
-import com.microsoft.Malmo.Schemas.ClientAgentConnection;
-import com.microsoft.Malmo.Schemas.MissionDiagnostics;
-import com.microsoft.Malmo.Schemas.MissionDiagnostics.VideoData;
-import com.microsoft.Malmo.Schemas.MissionInit;
-import com.microsoft.Malmo.Utils.TCPSocketChannel;
-import com.microsoft.Malmo.Utils.TextureHelper;
-
 
 /**
  * Register this class on the MinecraftForge.EVENT_BUS to intercept video
@@ -57,343 +56,354 @@ import com.microsoft.Malmo.Utils.TextureHelper;
  * We use this to send video frames over sockets.
  */
 public class VideoHook {
-    /**
-     * If the sockets are not yet open we delay before retrying. Value is in
-     * nanoseconds.
-     */
-    private static final long RETRY_GAP_NS = 5000000000L;
+  /**
+   * If the sockets are not yet open we delay before retrying. Value is in
+   * nanoseconds.
+   */
+  private static final long RETRY_GAP_NS = 5000000000L;
 
-    /**
-     * The time in nanoseconds after which we should try sending again.
-     */
-    private long retry_time_ns = 0;
+  /**
+   * The time in nanoseconds after which we should try sending again.
+   */
+  private long retry_time_ns = 0;
 
-    /**
-     * Calling stop() if we're not running is a no-op.
-     */
-    private boolean isRunning = false;
+  /**
+   * Calling stop() if we're not running is a no-op.
+   */
+  private boolean isRunning = false;
 
-    /**
-     * MissionInit object for passing to the IVideoProducer.
-     */
-    private MissionInit missionInit;
+  /**
+   * MissionInit object for passing to the IVideoProducer.
+   */
+  private MissionInit missionInit;
 
-    /**
-     * Object that will provide the actual video frame on demand.
-     */
-    private IVideoProducer videoProducer;
+  /**
+   * Object that will provide the actual video frame on demand.
+   */
+  private IVideoProducer videoProducer;
 
-    /**
-     * Public count of consecutive TCP failures - used to terminate a mission if nothing is listening
-     */
-    public int failedTCPSendCount = 0;
+  /**
+   * Public count of consecutive TCP failures - used to terminate a mission if
+   * nothing is listening
+   */
+  public int failedTCPSendCount = 0;
 
-    /**
-     * Object which maintains our connection to the agent.
-     */
-    private TCPSocketChannel connection = null;
-    
-    private int renderWidth;
-    
-    private int renderHeight;
+  /**
+   * Object which maintains our connection to the agent.
+   */
+  private TCPSocketChannel connection = null;
 
-    ByteBuffer buffer = null;
-    ByteBuffer headerbuffer = null;
-    final int POS_HEADER_SIZE = 20; // 20 bytes for the five floats governing x,y,z,yaw and pitch.
+  private int renderWidth;
 
-    // For diagnostic purposes:
-    private long timeOfFirstFrame = 0;
-    private long timeOfLastFrame = 0;
-    private long framesSent = 0;
-    private VideoProducedObserver observer;
+  private int renderHeight;
 
-    private MalmoEnvServer envServer = null;
+  ByteBuffer buffer = null;
+  ByteBuffer headerbuffer = null;
+  final int POS_HEADER_SIZE =
+      20; // 20 bytes for the five floats governing x,y,z,yaw and pitch.
 
-    /**
-     * Resize the rendering and start sending video over TCP.
-     */
-    public void start(MissionInit missionInit, IVideoProducer videoProducer, VideoProducedObserver observer, MalmoEnvServer envServer)
-    {
-        if (videoProducer == null)
-        {
-            return; // Don't start up if there is nothing to provide the video.
-        }
+  // For diagnostic purposes:
+  private long timeOfFirstFrame = 0;
+  private long timeOfLastFrame = 0;
+  private long framesSent = 0;
+  private VideoProducedObserver observer;
 
-        videoProducer.prepare(missionInit);
-        this.missionInit = missionInit;
-        this.videoProducer = videoProducer;
-        this.observer = observer;
-        this.envServer = envServer;
-        this.buffer = BufferUtils.createByteBuffer(this.videoProducer.getRequiredBufferSize());
-        this.headerbuffer = ByteBuffer.allocate(20).order(ByteOrder.BIG_ENDIAN);
-        this.renderWidth = videoProducer.getWidth();
-        this.renderHeight = videoProducer.getHeight();
-        resizeIfNeeded();
-        Display.setResizable(false); // prevent the user from resizing using the window borders
+  private MalmoEnvServer envServer = null;
 
-        ClientAgentConnection cac = missionInit.getClientAgentConnection();
-        if (cac == null)
-            return;	// Don't start up if we don't have any connection details.
-
-        String agentIPAddress = cac.getAgentIPAddress();
-        int agentPort = 0;
-        switch (videoProducer.getVideoType())
-        {
-        case LUMINANCE:
-            agentPort = cac.getAgentLuminancePort();
-            break;
-        case DEPTH_MAP:
-            agentPort = cac.getAgentDepthPort();
-            break;
-        case VIDEO:
-            agentPort = cac.getAgentVideoPort();
-            break;
-        case COLOUR_MAP:
-            agentPort = cac.getAgentColourMapPort();
-            break;
-        }
-
-        this.connection = new TCPSocketChannel(agentIPAddress, agentPort, "vid");
-        this.failedTCPSendCount = 0;
-
-        try
-        {
-            MinecraftForge.EVENT_BUS.register(this);
-        }
-        catch(Exception e)
-        {
-            System.out.println("Failed to register video hook: " + e);
-        }
-        this.isRunning = true;
-    }
-    
-    /**
-     * Resizes the window and the Minecraft rendering if necessary. Set renderWidth and renderHeight first.
-     */
-    private void resizeIfNeeded()
-    {
-        // resize the window if we need to
-        int oldRenderWidth = Display.getWidth(); 
-        int oldRenderHeight = Display.getHeight();
-        if( this.renderWidth == oldRenderWidth && this.renderHeight == oldRenderHeight )
-            return;
-        
-        try {
-            int old_x = Display.getX();
-            int old_y = Display.getY();
-            Display.setLocation(old_x, old_y);
-            Display.setDisplayMode(new DisplayMode(this.renderWidth, this.renderHeight));
-            System.out.println("Resized the window");
-        } catch (LWJGLException e) {
-            System.out.println("Failed to resize the window!");
-            e.printStackTrace();
-        }
-        forceResize(this.renderWidth, this.renderHeight);
+  /**
+   * Resize the rendering and start sending video over TCP.
+   */
+  public void start(MissionInit missionInit,
+                    IVideoProducer videoProducer,
+                    VideoProducedObserver observer,
+                    MalmoEnvServer envServer) {
+    if (videoProducer == null) {
+      return; // Don't start up if there is nothing to provide the video.
     }
 
-    /**
-     * Stop sending video.
-     */
-    public void stop(MissionDiagnostics diags)
-    {
-        if( !this.isRunning )
-        {
-            return;
-        }
-        if (this.videoProducer != null)
-            this.videoProducer.cleanup();
+    videoProducer.prepare(missionInit);
+    this.missionInit = missionInit;
+    this.videoProducer = videoProducer;
+    this.observer = observer;
+    this.envServer = envServer;
+    this.buffer = BufferUtils.createByteBuffer(
+        this.videoProducer.getRequiredBufferSize());
+    this.headerbuffer = ByteBuffer.allocate(20).order(ByteOrder.BIG_ENDIAN);
+    this.renderWidth = videoProducer.getWidth();
+    this.renderHeight = videoProducer.getHeight();
+    resizeIfNeeded();
+    Display.setResizable(
+        false); // prevent the user from resizing using the window borders
 
-        // stop sending video frames
-        try
-        {
-            MinecraftForge.EVENT_BUS.unregister(this);
-        }
-        catch(Exception e)
-        {
-            System.out.println("Failed to unregister video hook: " + e);
-        }
-        // Close our TCP socket:
-        this.connection.close();
-        this.isRunning = false;
+    ClientAgentConnection cac = missionInit.getClientAgentConnection();
+    if (cac == null)
+      return; // Don't start up if we don't have any connection details.
 
-        // allow the user to resize the window again
-        Display.setResizable(true);
-
-        // And fill in some diagnostic data:
-        if (diags != null)
-        {
-            VideoData vd = new VideoData();
-            vd.setFrameType(this.videoProducer.getVideoType().toString());
-            vd.setFramesSent((int) this.framesSent);
-            if (this.timeOfLastFrame == this.timeOfFirstFrame)
-                vd.setAverageFpsSent(new BigDecimal(0));
-            else
-                vd.setAverageFpsSent(new BigDecimal(1000.0 * this.framesSent / (this.timeOfLastFrame - this.timeOfFirstFrame)));
-            diags.getVideoData().add(vd);
-        }
+    String agentIPAddress = cac.getAgentIPAddress();
+    int agentPort = 0;
+    switch (videoProducer.getVideoType()) {
+    case LUMINANCE:
+      agentPort = cac.getAgentLuminancePort();
+      break;
+    case DEPTH_MAP:
+      agentPort = cac.getAgentDepthPort();
+      break;
+    case VIDEO:
+      agentPort = cac.getAgentVideoPort();
+      break;
+    case COLOUR_MAP:
+      agentPort = cac.getAgentColourMapPort();
+      break;
     }
 
-    /**
-     * Called before and after the rendering of the world.
-     * 
-     * @param event
-     *            Contains information about the event.
-     */
-    @SubscribeEvent
-    public void onRender(RenderTickEvent event)
-    {
-        if( event.phase == Phase.START )
-        {
-            // this is here in case the user has resized the window during a mission
-            resizeIfNeeded();
-        }
+    this.connection = new TCPSocketChannel(agentIPAddress, agentPort, "vid");
+    this.failedTCPSendCount = 0;
+
+    try {
+      MinecraftForge.EVENT_BUS.register(this);
     }
-    
-    /**
-     * Called when the world has been rendered but not yet the GUI or player hand.
-     * 
-     * @param event
-     *            Contains information about the event (not used).
-     */
-    @SubscribeEvent
-    public void postRender(RenderWorldLastEvent event)
-    {
-        // Check that the video producer and frame type match - eg if this is a colourmap frame, then
-        // only the colourmap videoproducer needs to do anything.
-        boolean colourmapFrame = TextureHelper.colourmapFrame;
-        boolean colourmapVideoProducer = this.videoProducer.getVideoType() == VideoType.COLOUR_MAP;
-        if (colourmapFrame != colourmapVideoProducer)
-            return;
+    catch (Exception e) {
+      System.out.println("Failed to register video hook: " + e);
+    }
+    this.isRunning = true;
+  }
 
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
-        float x = (float) (player.lastTickPosX + (player.posX - player.lastTickPosX) * event.getPartialTicks());
-        float y = (float) (player.lastTickPosY + (player.posY - player.lastTickPosY) * event.getPartialTicks());
-        float z = (float) (player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * event.getPartialTicks());
-        float yaw = player.prevRotationYaw + (player.rotationYaw - player.prevRotationYaw) * event.getPartialTicks();
-        float pitch = player.prevRotationPitch + (player.rotationPitch - player.prevRotationPitch) * event.getPartialTicks();
+  /**
+   * Resizes the window and the Minecraft rendering if necessary. Set
+   * renderWidth and renderHeight first.
+   */
+  private void resizeIfNeeded() {
+    // resize the window if we need to
+    int oldRenderWidth = Display.getWidth();
+    int oldRenderHeight = Display.getHeight();
+    if (this.renderWidth == oldRenderWidth &&
+        this.renderHeight == oldRenderHeight)
+      return;
 
-        long time_before_ns = System.nanoTime();
+    try {
+      int old_x = Display.getX();
+      int old_y = Display.getY();
+      Display.setLocation(old_x, old_y);
+      Display.setDisplayMode(
+          new DisplayMode(this.renderWidth, this.renderHeight));
+      System.out.println("Resized the window");
+    }
+    catch (LWJGLException e) {
+      System.out.println("Failed to resize the window!");
+      e.printStackTrace();
+    }
+    forceResize(this.renderWidth, this.renderHeight);
+  }
 
-        if (observer != null)
-            observer.frameProduced();
+  /**
+   * Stop sending video.
+   */
+  public void stop(MissionDiagnostics diags) {
+    if (!this.isRunning) {
+      return;
+    }
+    if (this.videoProducer != null)
+      this.videoProducer.cleanup();
 
-        if (time_before_ns < retry_time_ns)
-            return;
+    // stop sending video frames
+    try {
+      MinecraftForge.EVENT_BUS.unregister(this);
+    }
+    catch (Exception e) {
+      System.out.println("Failed to unregister video hook: " + e);
+    }
+    // Close our TCP socket:
+    this.connection.close();
+    this.isRunning = false;
 
-        boolean success = false;
+    // allow the user to resize the window again
+    Display.setResizable(true);
 
-        long time_after_render_ns;
+    // And fill in some diagnostic data:
+    if (diags != null) {
+      VideoData vd = new VideoData();
+      vd.setFrameType(this.videoProducer.getVideoType().toString());
+      vd.setFramesSent((int)this.framesSent);
+      if (this.timeOfLastFrame == this.timeOfFirstFrame)
+        vd.setAverageFpsSent(new BigDecimal(0));
+      else
+        vd.setAverageFpsSent(
+            new BigDecimal(1000.0 * this.framesSent /
+                           (this.timeOfLastFrame - this.timeOfFirstFrame)));
+      diags.getVideoData().add(vd);
+    }
+  }
 
-        try
-        {
-            int size = this.videoProducer.getRequiredBufferSize();
+  /**
+   * Called before and after the rendering of the world.
+   *
+   * @param event
+   *            Contains information about the event.
+   */
+  @SubscribeEvent
+  public void onRender(RenderTickEvent event) {
+    if (event.phase == Phase.START) {
+      // this is here in case the user has resized the window during a mission
+      resizeIfNeeded();
+    }
+  }
 
-            if (AddressHelper.getMissionControlPort() == 0) {
-                success = true;
+  /**
+   * Called when the world has been rendered but not yet the GUI or player hand.
+   *
+   * @param event
+   *            Contains information about the event (not used).
+   */
+  @SubscribeEvent
+  public void postRender(RenderWorldLastEvent event) {
+    // Check that the video producer and frame type match - eg if this is a
+    // colourmap frame, then only the colourmap videoproducer needs to do
+    // anything.
+    boolean colourmapFrame = TextureHelper.colourmapFrame;
+    boolean colourmapVideoProducer =
+        this.videoProducer.getVideoType() == VideoType.COLOUR_MAP;
+    if (colourmapFrame != colourmapVideoProducer)
+      return;
 
-                if (envServer != null) {
-                    // Write the obs data into a newly allocated buffer:
-                    byte[] data = new byte[size];
-                    this.buffer.clear();
-                    this.videoProducer.getFrame(this.missionInit, this.buffer);
-                    this.buffer.get(data); // Avoiding copy not simple as data is kept & written to a stream later.
-                    time_after_render_ns = System.nanoTime();
+    EntityPlayerSP player = Minecraft.getMinecraft().player;
+    float x =
+        (float)(player.lastTickPosX +
+                (player.posX - player.lastTickPosX) * event.getPartialTicks());
+    float y =
+        (float)(player.lastTickPosY +
+                (player.posY - player.lastTickPosY) * event.getPartialTicks());
+    float z =
+        (float)(player.lastTickPosZ +
+                (player.posZ - player.lastTickPosZ) * event.getPartialTicks());
+    float yaw =
+        player.prevRotationYaw +
+        (player.rotationYaw - player.prevRotationYaw) * event.getPartialTicks();
+    float pitch = player.prevRotationPitch +
+                  (player.rotationPitch - player.prevRotationPitch) *
+                      event.getPartialTicks();
 
-                    envServer.addFrame(data);
-                } else {
-                    time_after_render_ns = System.nanoTime();
-                }
-            } else {
-                // Get buffer ready for writing to:
-                this.buffer.clear();
-                this.headerbuffer.clear();
-                // Write the pos data:
-                this.headerbuffer.putFloat(x);
-                this.headerbuffer.putFloat(y);
-                this.headerbuffer.putFloat(z);
-                this.headerbuffer.putFloat(yaw);
-                this.headerbuffer.putFloat(pitch);
-                // Write the frame data:
-                this.videoProducer.getFrame(this.missionInit, this.buffer);
-                // The buffer gets flipped by getFrame(), but we need to flip our header buffer ourselves:
-                this.headerbuffer.flip();
-                ByteBuffer[] buffers = {this.headerbuffer, this.buffer};
-                time_after_render_ns = System.nanoTime();
+    long time_before_ns = System.nanoTime();
 
-                success = this.connection.sendTCPBytes(buffers, size + POS_HEADER_SIZE);
-            }
+    if (observer != null)
+      observer.frameProduced();
 
-            long time_after_ns = System.nanoTime();
-            float ms_send = (time_after_ns - time_after_render_ns) / 1000000.0f;
-            float ms_render = (time_after_render_ns - time_before_ns) / 1000000.0f;
-            if (success)
-            {
-                this.failedTCPSendCount = 0;    // Reset count of failed sends.
-                this.timeOfLastFrame = System.currentTimeMillis();
-                if (this.timeOfFirstFrame == 0)
-                	this.timeOfFirstFrame = this.timeOfLastFrame;
-                this.framesSent++;
-	            //            System.out.format("Total: %.2fms; collecting took %.2fms; sending %d bytes took %.2fms\n", ms_send + ms_render, ms_render, size, ms_send);
-	            //            System.out.println("Collect: " + ms_render + "; Send: " + ms_send);
-            }
+    if (time_before_ns < retry_time_ns)
+      return;
+
+    boolean success = false;
+
+    long time_after_render_ns;
+
+    try {
+      int size = this.videoProducer.getRequiredBufferSize();
+
+      if (AddressHelper.getMissionControlPort() == 0) {
+        success = true;
+
+        if (envServer != null) {
+          // Write the obs data into a newly allocated buffer:
+          byte[] data = new byte[size];
+          this.buffer.clear();
+          this.videoProducer.getFrame(this.missionInit, this.buffer);
+          this.buffer.get(data); // Avoiding copy not simple as data is kept &
+                                 // written to a stream later.
+          time_after_render_ns = System.nanoTime();
+
+          envServer.addFrame(data);
         }
-        catch (Exception e)
-        {
-            System.out.format(e.getMessage());
+        else {
+          time_after_render_ns = System.nanoTime();
         }
-        
-        if (!success) {
-            System.out.format("Failed to send frame - will retry in %d seconds\n", RETRY_GAP_NS / 1000000000L);
-            retry_time_ns = time_before_ns + RETRY_GAP_NS;
-            this.failedTCPSendCount++;
-        }
+      }
+      else {
+        // Get buffer ready for writing to:
+        this.buffer.clear();
+        this.headerbuffer.clear();
+        // Write the pos data:
+        this.headerbuffer.putFloat(x);
+        this.headerbuffer.putFloat(y);
+        this.headerbuffer.putFloat(z);
+        this.headerbuffer.putFloat(yaw);
+        this.headerbuffer.putFloat(pitch);
+        // Write the frame data:
+        this.videoProducer.getFrame(this.missionInit, this.buffer);
+        // The buffer gets flipped by getFrame(), but we need to flip our header
+        // buffer ourselves:
+        this.headerbuffer.flip();
+        ByteBuffer[] buffers = {this.headerbuffer, this.buffer};
+        time_after_render_ns = System.nanoTime();
+
+        success = this.connection.sendTCPBytes(buffers, size + POS_HEADER_SIZE);
+      }
+
+      long time_after_ns = System.nanoTime();
+      float ms_send = (time_after_ns - time_after_render_ns) / 1000000.0f;
+      float ms_render = (time_after_render_ns - time_before_ns) / 1000000.0f;
+      if (success) {
+        this.failedTCPSendCount = 0; // Reset count of failed sends.
+        this.timeOfLastFrame = System.currentTimeMillis();
+        if (this.timeOfFirstFrame == 0)
+          this.timeOfFirstFrame = this.timeOfLastFrame;
+        this.framesSent++;
+        //            System.out.format("Total: %.2fms; collecting took %.2fms;
+        //            sending %d bytes took %.2fms\n", ms_send + ms_render,
+        //            ms_render, size, ms_send); System.out.println("Collect: "
+        //            + ms_render + "; Send: " + ms_send);
+      }
+    }
+    catch (Exception e) {
+      System.out.format(e.getMessage());
     }
 
-    /** Force Minecraft to resize its GUI
-     * @param width new width of window
-     * @param height new height of window
-     */
-    private void forceResize(int width, int height)
-    {
-        // Are we in the dev environment or deployed?
-        boolean devEnv = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
-        // We need to know, because the method name will either be obfuscated or not.
-        String resizeMethodName = devEnv ? "resize" : "func_71370_a";
-
-        Class[] cArgs = new Class[2];
-        cArgs[0] = int.class;
-        cArgs[1] = int.class;
-        Method resize;
-        try
-        {
-            resize = Minecraft.class.getDeclaredMethod(resizeMethodName, cArgs);
-            resize.setAccessible(true);
-            resize.invoke(Minecraft.getMinecraft(), width, height);
-        }
-        catch (NoSuchMethodException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch (SecurityException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch (IllegalAccessException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch (IllegalArgumentException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch (InvocationTargetException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+    if (!success) {
+      System.out.format("Failed to send frame - will retry in %d seconds\n",
+                        RETRY_GAP_NS / 1000000000L);
+      retry_time_ns = time_before_ns + RETRY_GAP_NS;
+      this.failedTCPSendCount++;
     }
+  }
+
+  /**
+   * Force Minecraft to resize its GUI
+   * @param width new width of window
+   * @param height new height of window
+   */
+  private void forceResize(int width, int height) {
+    // Are we in the dev environment or deployed?
+    boolean devEnv =
+        (Boolean)Launch.blackboard.get("fml.deobfuscatedEnvironment");
+    // We need to know, because the method name will either be obfuscated or
+    // not.
+    String resizeMethodName = devEnv ? "resize" : "func_71370_a";
+
+    Class[] cArgs = new Class[2];
+    cArgs[0] = int.class;
+    cArgs[1] = int.class;
+    Method resize;
+    try {
+      resize = Minecraft.class.getDeclaredMethod(resizeMethodName, cArgs);
+      resize.setAccessible(true);
+      resize.invoke(Minecraft.getMinecraft(), width, height);
+    }
+    catch (NoSuchMethodException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    catch (SecurityException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    catch (IllegalAccessException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    catch (IllegalArgumentException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    catch (InvocationTargetException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+  }
 }

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlerInterfaces/IVideoProducer.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlerInterfaces/IVideoProducer.java
@@ -1,62 +1,66 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 package com.microsoft.Malmo.MissionHandlerInterfaces;
 
+import com.microsoft.Malmo.Schemas.MissionInit;
 import java.nio.ByteBuffer;
 
-import com.microsoft.Malmo.Schemas.MissionInit;
-
-/** Interface for objects which are responsible for providing Minecraft video data.
+/**
+ * Interface for objects which are responsible for providing Minecraft video
+ * data.
  */
-public interface IVideoProducer
-{
-    public enum VideoType
-    {
-        VIDEO,
-        DEPTH_MAP,
-        LUMINANCE,
-        COLOUR_MAP
-    };
+public interface IVideoProducer {
+  public enum VideoType { VIDEO, DEPTH_MAP, LUMINANCE, COLOUR_MAP }
+  ;
 
-    /** Get the type of video frames returned.*/
-    public VideoType getVideoType();
+  /** Get the type of video frames returned.*/
+  public VideoType getVideoType();
 
-    /** Get a frame of video from Minecraft.
-     * @param missionInit the MissionInit object for the currently running mission, which may contain parameters for the video requirements.
-     * @return an array of bytes representing this frame.<br>
-     * (The format is unspecified; it is up to the IVideoProducer implementation and the agent to agree on how the data is formatted.)
-     */
-    public void getFrame(MissionInit missionInit, ByteBuffer buffer);
-    
-    /** Get the requested width of the video frames returned.*/
-    public int getWidth();
+  /**
+   * Get a frame of video from Minecraft.
+   * @param missionInit the MissionInit object for the currently running
+   *     mission, which may contain parameters for the video requirements.
+   * @return an array of bytes representing this frame.<br>
+   * (The format is unspecified; it is up to the IVideoProducer implementation
+   * and the agent to agree on how the data is formatted.)
+   */
+  public void getFrame(MissionInit missionInit, ByteBuffer buffer);
 
-    /** Get the requested height of the video frames returned.*/
-    public int getHeight();
-    
-    /** Get the number of bytes required to store a frame.*/
-    public int getRequiredBufferSize();
-    
-    /** Called once before the mission starts - use for any necessary initialisation.*/
-    public void prepare(MissionInit missionInit);
-    
-    /** Called once after the mission ends - use for any necessary cleanup.*/
-    public void cleanup();
+  /** Get the requested width of the video frames returned.*/
+  public int getWidth();
+
+  /** Get the requested height of the video frames returned.*/
+  public int getHeight();
+
+  /** Get the number of bytes required to store a frame.*/
+  public int getRequiredBufferSize();
+
+  /**
+   * Called once before the mission starts - use for any necessary
+   * initialisation.
+   */
+  public void prepare(MissionInit missionInit);
+
+  /** Called once after the mission ends - use for any necessary cleanup.*/
+  public void cleanup();
 }

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VideoProducerImplementation.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/VideoProducerImplementation.java
@@ -1,20 +1,23 @@
 // --------------------------------------------------------------------------------------------------
 //  Copyright (c) 2016 Microsoft Corporation
-//  
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//  associated documentation files (the "Software"), to deal in the Software without restriction,
-//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
-//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
-//  
-//  The above copyright notice and this permission notice shall be included in all copies or
-//  substantial portions of the Software.
-//  
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 // --------------------------------------------------------------------------------------------------
 
 package com.microsoft.Malmo.MissionHandlers;
@@ -26,168 +29,170 @@ import static org.lwjgl.opengl.GL11.GL_RGBA;
 import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
 import static org.lwjgl.opengl.GL11.glReadPixels;
 
+import com.microsoft.Malmo.MissionHandlerInterfaces.IVideoProducer;
+import com.microsoft.Malmo.Schemas.MissionInit;
+import com.microsoft.Malmo.Schemas.VideoProducer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.shader.Framebuffer;
-
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
-import com.microsoft.Malmo.MissionHandlerInterfaces.IVideoProducer;
-import com.microsoft.Malmo.Schemas.MissionInit;
-import com.microsoft.Malmo.Schemas.VideoProducer;
+public class VideoProducerImplementation
+    extends HandlerBase implements IVideoProducer {
+  private VideoProducer videoParams;
+  private Framebuffer fbo;
+  private FloatBuffer depthBuffer;
 
-public class VideoProducerImplementation extends HandlerBase implements IVideoProducer
-{
-    private VideoProducer videoParams;
-    private Framebuffer fbo;
-    private FloatBuffer depthBuffer;
+  @Override
+  public boolean parseParameters(Object params) {
+    if (params == null || !(params instanceof VideoProducer))
+      return false;
+    this.videoParams = (VideoProducer)params;
 
-    @Override
-    public boolean parseParameters(Object params)
-    {
-        if (params == null || !(params instanceof VideoProducer))
-            return false;
-        this.videoParams = (VideoProducer) params;
+    return true;
+  }
 
-        return true;
+  @Override
+  public VideoType getVideoType() {
+    return VideoType.VIDEO;
+  }
+
+  @Override
+  public void getFrame(MissionInit missionInit, ByteBuffer buffer) {
+    if (!this.videoParams.isWantDepth()) {
+      getRGBFrame(buffer); // Just return the simple RGB, 3bpp image.
+      return;
     }
 
-    @Override
-    public VideoType getVideoType()
-    {
-        return VideoType.VIDEO;
+    // Otherwise, do the work of extracting the depth map:
+    final int width = this.videoParams.getWidth();
+    final int height = this.videoParams.getHeight();
+
+    GL30.glBindFramebuffer(
+        GL30.GL_READ_FRAMEBUFFER,
+        Minecraft.getMinecraft().getFramebuffer().framebufferObject);
+    GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER,
+                           this.fbo.framebufferObject);
+    GL30.glBlitFramebuffer(
+        0,
+        0,
+        Minecraft.getMinecraft().getFramebuffer().framebufferWidth,
+        Minecraft.getMinecraft().getFramebuffer().framebufferHeight,
+        0,
+        0,
+        width,
+        height,
+        GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT,
+        GL11.GL_NEAREST);
+
+    this.fbo.bindFramebuffer(true);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
+    glReadPixels(
+        0, 0, width, height, GL_DEPTH_COMPONENT, GL_FLOAT, this.depthBuffer);
+    this.fbo.unbindFramebuffer();
+
+    // Now convert the depth buffer into values from 0-255 and copy it over
+    // the alpha channel.
+    // We either use the min and max values supplied in order to scale it,
+    // or we scale it according
+    // to the dynamic content:
+    float minval, maxval;
+
+    // The scaling section is optional (since the depthmap is optional) - so
+    // if there is no depthScaling object,
+    // go with the default of autoscale.
+    if (this.videoParams.getDepthScaling() == null ||
+        this.videoParams.getDepthScaling().isAutoscale()) {
+      minval = 1;
+      maxval = 0;
+      for (int i = 0; i < width * height; i++) {
+        float f = this.depthBuffer.get(i);
+        if (f < minval)
+          minval = f;
+        if (f > maxval)
+          maxval = f;
+      }
     }
-
-    @Override
-    public void getFrame(MissionInit missionInit, ByteBuffer buffer)
-    {
-        if (!this.videoParams.isWantDepth())
-        {
-            getRGBFrame(buffer); // Just return the simple RGB, 3bpp image.
-            return;
-        }
-
-        // Otherwise, do the work of extracting the depth map:
-        final int width = this.videoParams.getWidth();
-        final int height = this.videoParams.getHeight();
-
-        GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, Minecraft.getMinecraft().getFramebuffer().framebufferObject);
-        GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, this.fbo.framebufferObject);
-        GL30.glBlitFramebuffer(0, 0, Minecraft.getMinecraft().getFramebuffer().framebufferWidth, Minecraft.getMinecraft().getFramebuffer().framebufferHeight, 0, 0, width, height, GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT, GL11.GL_NEAREST);
-
-        this.fbo.bindFramebuffer(true);
-        glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
-        glReadPixels(0, 0, width, height, GL_DEPTH_COMPONENT, GL_FLOAT, this.depthBuffer);
-        this.fbo.unbindFramebuffer();
-
-        // Now convert the depth buffer into values from 0-255 and copy it over
-        // the alpha channel.
-        // We either use the min and max values supplied in order to scale it,
-        // or we scale it according
-        // to the dynamic content:
-        float minval, maxval;
-
-        // The scaling section is optional (since the depthmap is optional) - so
-        // if there is no depthScaling object,
-        // go with the default of autoscale.
-        if (this.videoParams.getDepthScaling() == null || this.videoParams.getDepthScaling().isAutoscale())
-        {
-            minval = 1;
-            maxval = 0;
-            for (int i = 0; i < width * height; i++)
-            {
-                float f = this.depthBuffer.get(i);
-                if (f < minval)
-                    minval = f;
-                if (f > maxval)
-                    maxval = f;
-            }
-        }
-        else
-        {
-            minval = this.videoParams.getDepthScaling().getMin().floatValue();
-            maxval = this.videoParams.getDepthScaling().getMax().floatValue();
-            if (minval > maxval)
-            {
-                // You can't trust users.
-                float t = minval;
-                minval = maxval;
-                maxval = t;
-            }
-        }
-        float range = maxval - minval;
-        if (range < 0.000001)
-            range = 0.000001f; // To avoid divide by zero errors in cases where
-                               // there is no depth variance
-        float scale = 255 / range;
-        for (int i = 0; i < width * height; i++)
-        {
-            float f = this.depthBuffer.get(i);
-            f = (f < minval ? minval : (f > maxval ? maxval : f));
-            f -= minval;
-            f *= scale;
-            buffer.put(i * 4 + 3, (byte) f);
-        }
-        // Reset depth buffer ready for next read:
-        this.depthBuffer.clear();
+    else {
+      minval = this.videoParams.getDepthScaling().getMin().floatValue();
+      maxval = this.videoParams.getDepthScaling().getMax().floatValue();
+      if (minval > maxval) {
+        // You can't trust users.
+        float t = minval;
+        minval = maxval;
+        maxval = t;
+      }
     }
-
-    @Override
-    public int getWidth()
-    {
-        return this.videoParams.getWidth();
+    float range = maxval - minval;
+    if (range < 0.000001)
+      range = 0.000001f; // To avoid divide by zero errors in cases where
+                         // there is no depth variance
+    float scale = 255 / range;
+    for (int i = 0; i < width * height; i++) {
+      float f = this.depthBuffer.get(i);
+      f = (f < minval ? minval : (f > maxval ? maxval : f));
+      f -= minval;
+      f *= scale;
+      buffer.put(i * 4 + 3, (byte)f);
     }
+    // Reset depth buffer ready for next read:
+    this.depthBuffer.clear();
+  }
 
-    @Override
-    public int getHeight()
-    {
-        return this.videoParams.getHeight();
-    }
+  @Override
+  public int getWidth() {
+    return this.videoParams.getWidth();
+  }
 
-    public int getRequiredBufferSize()
-    {
-        return this.videoParams.getWidth() * this.videoParams.getHeight() * (this.videoParams.isWantDepth() ? 4 : 3);
-    }
+  @Override
+  public int getHeight() {
+    return this.videoParams.getHeight();
+  }
 
-    private void getRGBFrame(ByteBuffer buffer)
-    {
-        final int format = GL_RGB;
-        final int width = this.videoParams.getWidth();
-        final int height = this.videoParams.getHeight();
+  public int getRequiredBufferSize() {
+    return this.videoParams.getWidth() * this.videoParams.getHeight() *
+        (this.videoParams.isWantDepth() ? 4 : 3);
+  }
 
-        // Render the Minecraft frame into our own FBO, at the desired size:
-        this.fbo.bindFramebuffer(true);
-        Minecraft.getMinecraft().getFramebuffer().framebufferRenderExt(width, height, true);
-        // Now read the pixels out from that:
-        // glReadPixels appears to be faster than doing:
-        // GlStateManager.bindTexture(this.fbo.framebufferTexture);
-        // GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, format, GL_UNSIGNED_BYTE,
-        // buffer);
-        glReadPixels(0, 0, width, height, format, GL_UNSIGNED_BYTE, buffer);
-        this.fbo.unbindFramebuffer();
-        GlStateManager.enableDepth();
-        Minecraft.getMinecraft().getFramebuffer().bindFramebuffer(true);
-    }
+  private void getRGBFrame(ByteBuffer buffer) {
+    final int format = GL_RGB;
+    final int width = this.videoParams.getWidth();
+    final int height = this.videoParams.getHeight();
 
-    @Override
-    public void prepare(MissionInit missionInit)
-    {
-        this.fbo = new Framebuffer(this.videoParams.getWidth(), this.videoParams.getHeight(), true);
-        // Create a buffer for retrieving the depth map, if requested:
-        if (this.videoParams.isWantDepth())
-            this.depthBuffer = BufferUtils.createFloatBuffer(this.videoParams.getWidth() * this.videoParams.getHeight());
-        // Set the requested camera position
-        Minecraft.getMinecraft().gameSettings.thirdPersonView = this.videoParams.getViewpoint();
-    }
+    // Render the Minecraft frame into our own FBO, at the desired size:
+    this.fbo.bindFramebuffer(true);
+    Minecraft.getMinecraft().getFramebuffer().framebufferRenderExt(
+        width, height, true);
+    // Now read the pixels out from that:
+    // glReadPixels appears to be faster than doing:
+    // GlStateManager.bindTexture(this.fbo.framebufferTexture);
+    // GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, format, GL_UNSIGNED_BYTE,
+    // buffer);
+    glReadPixels(0, 0, width, height, format, GL_UNSIGNED_BYTE, buffer);
+    this.fbo.unbindFramebuffer();
+    GlStateManager.enableDepth();
+    Minecraft.getMinecraft().getFramebuffer().bindFramebuffer(true);
+  }
 
-    @Override
-    public void cleanup()
-    {
-        this.fbo.deleteFramebuffer(); // Must do this or we leak resources.
-    }
+  @Override
+  public void prepare(MissionInit missionInit) {
+    this.fbo = new Framebuffer(
+        this.videoParams.getWidth(), this.videoParams.getHeight(), true);
+    // Create a buffer for retrieving the depth map, if requested:
+    if (this.videoParams.isWantDepth())
+      this.depthBuffer = BufferUtils.createFloatBuffer(
+          this.videoParams.getWidth() * this.videoParams.getHeight());
+    // Set the requested camera position
+    Minecraft.getMinecraft().gameSettings.thirdPersonView =
+        this.videoParams.getViewpoint();
+  }
+
+  @Override
+  public void cleanup() {
+    this.fbo.deleteFramebuffer(); // Must do this or we leak resources.
+  }
 }

--- a/tools/check_minecraft.sh
+++ b/tools/check_minecraft.sh
@@ -2,18 +2,14 @@
 
 set -u 
 
-export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
-mkdir -p "${TOMCAT_TMP_DIR}"
-if [[ $? -ne 0 ]]; then exit 1; fi;
- 
 minecraft_log="${TOMCAT_TMP_DIR}/minecraft.log"
 minecraft_launch_pid_file="${TOMCAT_TMP_DIR}/minecraft_launch.pid"
 
 exit_status=1
 num_tries=1
 
-# Likely a bit more robust and easier to debug if we give Minecraft some time to
-# start. However, this is optional.
+# Likely a bit more robust and easier to debug if we give Minecraft some time
+# to start. However, this is optional.
 
 initial_wait=10 
 

--- a/tools/check_minecraft.sh
+++ b/tools/check_minecraft.sh
@@ -2,27 +2,6 @@
 
 set -u 
 
-###############################################################################
-
-# If TOMCAT is set as an enviroment variable, we will respect it. 
-
-declare -x TOMCAT
-if [ ! -z "$TOMCAT" ]; then
-    echo "Script check_minecraft is using requested TOMCAT location ${TOMCAT}."
-else 
-    # This script should be in a directory 'tools' which should be a subdirectory of
-    # the TOMCAT directory. The following uses those assumptions to determine
-    # the TOMCAT environment variable.
-    #
-    called_as_dir=`echo $0 | sed 's#^[^/][^/]*$#./#'`
-    called_as_dir=`echo $called_as_dir | sed 's#^\(.*\)/.*$#\1#'`
-    pushd "${called_as_dir}" > /dev/null; called_as_dir=`pwd`; popd > /dev/null
-    export TOMCAT=`echo $called_as_dir | sed 's#^\./##' | sed 's#^\(.*\)/tools$#\1#'`
-    echo "Script check_minecraft is using inferred TOMCAT location ${TOMCAT}."
-fi
-
-###############################################################################
-
 export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
 mkdir -p "${TOMCAT_TMP_DIR}"
 if [[ $? -ne 0 ]]; then exit 1; fi;

--- a/tools/check_minecraft.sh
+++ b/tools/check_minecraft.sh
@@ -12,13 +12,13 @@ if [ ! -z "$TOMCAT" ]; then
 else 
     # This script should be in a directory 'tools' which should be a subdirectory of
     # the TOMCAT directory. The following uses those assumptions to determine
-    # TOMCAT.
+    # the TOMCAT environment variable.
     #
     called_as_dir=`echo $0 | sed 's#^[^/][^/]*$#./#'`
     called_as_dir=`echo $called_as_dir | sed 's#^\(.*\)/.*$#\1#'`
     pushd "${called_as_dir}" > /dev/null; called_as_dir=`pwd`; popd > /dev/null
     export TOMCAT=`echo $called_as_dir | sed 's#^\./##' | sed 's#^\(.*\)/tools$#\1#'`
-    echo "Script check_minecraft is using inferreed TOMCAT location ${TOMCAT}."
+    echo "Script check_minecraft is using inferred TOMCAT location ${TOMCAT}."
 fi
 
 ###############################################################################
@@ -35,7 +35,7 @@ num_tries=1
 
 # Likely a bit more robust and easier to debug if we give Minecraft some time to
 # start. However, this is optional.
-#
+
 initial_wait=10 
 
 num_seconds_to_wait=300
@@ -133,7 +133,7 @@ while [ $try -lt $num_tries ]; do
     fi 
 
     ${TOMCAT}/tools/kill_minecraft.sh
-# 
+
 #     sleep 1
 #     /bin/rm -f "${minecraft_log}"
 #     sleep 1
@@ -146,7 +146,7 @@ if [[ ${exit_status} -ne 0 ]]; then
 fi 
 
 if [[ ${launch_client_failed} -ne 0 ]]; then
-    echo "Last failure was becuase Minecraft failed to launch."
+    echo "Last failure was because Minecraft failed to launch."
     echo "The log file follows".
     echo ""
     cat ${minecraft_log}
@@ -157,4 +157,3 @@ echo "Finished checking Minecraft with with exit_status ${exit_status}."
 echo " "
 
 exit ${exit_status}
-

--- a/tools/download_OpenFace_models.sh
+++ b/tools/download_OpenFace_models.sh
@@ -16,3 +16,4 @@ popd > /dev/null
 
 echo "OpenFace models download complete."
 echo " "
+exit 0

--- a/tools/download_tomcat_worlds.sh
+++ b/tools/download_tomcat_worlds.sh
@@ -2,31 +2,9 @@
 
 # Script to download Minecraft worlds for ToMCAT
 
-# Kobus says: 'set -e' does not make sense if you are checking returns as you
-# are doing.
-#
-# set -e
-
-###############################################################################
-
-# If TOMCAT is set as an enviroment variable, we will respect it. 
-
-declare -x TOMCAT
-if [ ! -z "$TOMCAT" ]; then
-    echo "Script download_tomcat_worlds is using requested TOMCAT location ${TOMCAT}."
-else 
-    # This script should be in a directory 'tools' which should be a subdirectory of
-    # the TOMCAT directory. The following uses those assumptions to determine
-    # TOMCAT.
-    #
-    called_as_dir=`echo $0 | sed 's#^[^/][^/]*$#./#'`
-    called_as_dir=`echo $called_as_dir | sed 's#^\(.*\)/.*$#\1#'`
-    pushd "${called_as_dir}" > /dev/null; called_as_dir=`pwd`; popd > /dev/null
-    export TOMCAT=`echo $called_as_dir | sed 's#^\./##' | sed 's#^\(.*\)/tools$#\1#'`
-    echo "Script check_minecraft is using inferreed TOMCAT location ${TOMCAT}."
-fi
-
-###############################################################################
+# Set the TOMCAT environment variable, assuming that the directory structure
+# mirrors that of the git repository.
+export TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
 
 echo "Downloading ToMCAT Minecraft worlds."
 

--- a/tools/download_tomcat_worlds.sh
+++ b/tools/download_tomcat_worlds.sh
@@ -2,7 +2,7 @@
 
 # Script to download Minecraft worlds for ToMCAT
 
-# Kobus says 'set -e' does not make sense if you are checking returns as you
+# Kobus says: 'set -e' does not make sense if you are checking returns as you
 # are doing.
 #
 # set -e
@@ -13,7 +13,7 @@
 
 declare -x TOMCAT
 if [ ! -z "$TOMCAT" ]; then
-    echo "Script check_minecraft is using requested TOMCAT location ${TOMCAT}."
+    echo "Script download_tomcat_worlds is using requested TOMCAT location ${TOMCAT}."
 else 
     # This script should be in a directory 'tools' which should be a subdirectory of
     # the TOMCAT directory. The following uses those assumptions to determine
@@ -40,3 +40,4 @@ popd > /dev/null
 
 echo "ToMCAT worlds download complete."
 echo " "
+exit 0

--- a/tools/get_minecraft_window_position_and_size.scpt
+++ b/tools/get_minecraft_window_position_and_size.scpt
@@ -1,0 +1,8 @@
+-- Script to get the window size and position of Minecraft for ffmpeg on macOS
+
+tell application "System Events" to tell application process "java"
+  set windowposition to position of window 1
+  set windowsize to size of window 1
+end tell
+
+windowposition & windowsize

--- a/tools/get_minecraft_window_position_and_size.scpt
+++ b/tools/get_minecraft_window_position_and_size.scpt
@@ -1,4 +1,4 @@
--- Script to get the window size and position of Minecraft for ffmpeg on macOS
+-- Script to get the window size and position of the Minecraft window on macOS.
 
 tell application "System Events" to tell application process "java"
   set windowposition to position of window 1

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -93,4 +93,4 @@ popd > /dev/null
 echo " "
 echo "Finished installing ToMCAT in ${TOMCAT}!"
 echo " "
-
+exit 0

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -7,31 +7,11 @@
 # script that is supposed to install things we might need, counting on as little
 # as possible.
 
-# set -x 
+# Set the TOMCAT environment variable, assuming that the directory structure
+# mirrors that of the git repository.
+export TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
 
 ###############################################################################
-
-# If TOMCAT is set as an enviroment variable, we will respect it. We do not use
-# the tcsh trick to test this because tcsh might not be installed yet. 
-
-if [ ! -z "$TOMCAT" ]; then
-    echo "Using requested TOMCAT location ${TOMCAT}."
-else 
-    # This script should be in a directory 'tools' which should be a subdirectory of
-    # the TOMCAT directory. The following uses those assumptions to determine
-    # TOMCAT.
-    #
-    called_as_dir=`echo $0 | sed 's#^[^/][^/]*$#./#'`
-    called_as_dir=`echo $called_as_dir | sed 's#^\(.*\)/.*$#\1#'`
-    pushd "${called_as_dir}" > /dev/null; called_as_dir=`pwd`; popd > /dev/null
-    export TOMCAT=`echo $called_as_dir | sed 's#^\./##' | sed 's#^\(.*\)/tools$#\1#'`
-    echo "Using inferred TOMCAT location ${TOMCAT}."
-fi
-
-###############################################################################
-
-# Bug! Interacts badly with cmake!! 
-# declare -x TRAVIS
 
 ${TOMCAT}/tools/install_dependencies.sh
 if [[ $? -ne 0 ]]; then exit 1; fi;
@@ -81,7 +61,7 @@ pushd "${TOMCAT}"
         if [[ $? -ne 0 ]]; then exit 1; fi;
 
         # We skip building Minecraft on Travis since we cannot get an
-        # appropriate version of Java on their MacOS image.
+        # appropriate version of Java on their macOS image.
         if [[ -z $TRAVIS ]]; then
             make -j Minecraft
             if [[ $? -ne 0 ]]; then exit 1; fi;

--- a/tools/install_boost_from_source.sh
+++ b/tools/install_boost_from_source.sh
@@ -2,8 +2,10 @@
 
 # Install Boost from source
 
-wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+curl -O https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+if [[ $? -ne 0 ]]; then exit 1; fi;
 tar xfz boost_1_71_0.tar.gz
+if [[ $? -ne 0 ]]; then exit 1; fi;
 pushd boost_1_71_0
   ./bootstrap.sh
   if [[ $? -ne 0 ]]; then exit 1; fi;
@@ -11,3 +13,4 @@ pushd boost_1_71_0
   if [[ $? -ne 0 ]]; then exit 1; fi;
 popd
 rm -rf boost_1_71_0*
+exit 0

--- a/tools/install_dlib_from_source.sh
+++ b/tools/install_dlib_from_source.sh
@@ -21,3 +21,4 @@ pushd dlib
     if [[ $? -ne 0 ]]; then exit 1; fi;
   popd
 popd
+exit 0

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -11,26 +11,9 @@ mission_one_time=60
 do_tutorial=0
 do_invasion=1
 
-###############################################################################
-
-# If TOMCAT is set as an enviroment variable, we will respect it. 
-
-declare -x TOMCAT
-if [ ! -z "$TOMCAT" ]; then
-    echo "Script check_minecraft is using requested TOMCAT location ${TOMCAT}."
-else 
-    # This script should be in a directory 'tools' which should be a subdirectory of
-    # the TOMCAT directory. The following uses those assumptions to determine
-    # the TOMCAT environment variable.
-    #
-    called_as_dir=`echo $0 | sed 's#^[^/][^/]*$#./#'`
-    called_as_dir=`echo $called_as_dir | sed 's#^\(.*\)/.*$#\1#'`
-    pushd "${called_as_dir}" > /dev/null; called_as_dir=`pwd`; popd > /dev/null
-    export TOMCAT=`echo $called_as_dir | sed 's#^\./##' | sed 's#^\(.*\)/tools$#\1#'`
-    echo "Script check_minecraft is using inferred TOMCAT location ${TOMCAT}."
-fi
-
-###############################################################################
+# Set the TOMCAT environment variable, assuming that the directory structure
+# mirrors that of the git repository.
+export TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
 
 ${TOMCAT}/tools/check_minecraft.sh
 
@@ -53,8 +36,7 @@ if [[ ${do_tutorial} -eq 1 ]]; then
         ${TOMCAT}/build/bin/runExperiment --mission 0 >& ${tutorial_mission_log} &
         bg_pid=$!
         echo "Running: ${TOMCAT}/build/bin/runExperiment --mission 0"
-        echo "Process is $bg_pid" 
-        echo "Waiting for it"
+        echo "Process is $bg_pid - waiting for it"
         wait
         tutorial_mission_status=$?
 

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -14,7 +14,7 @@ do_invasion=1
 # Set the TOMCAT environment variable, assuming that the directory structure
 # mirrors that of the git repository.
 export TOMCAT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" >/dev/null 2>&1 && pwd)"
-export TOMCAT_TMP_DIR="${TOMCAT}/tmp"
+export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
 mkdir -p "${TOMCAT_TMP_DIR}"
 
 ${TOMCAT}/tools/check_minecraft.sh

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -94,6 +94,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
     the position and size of the Minecraft window. Equivalent functionality can
     probably be achieved with the wmctrl tool tool on Linux. Pull requests
     welcome!"
+      exit 1
     fi
 
     # Creating an output directory for this session. 

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -1,65 +1,32 @@
 #!/bin/bash
 
-set -u 
+set -u
 
 # this function returns the date and time in the current timezone.
 timestamp() {
-  date "+%Y_%m_%d_%H_%M_%S"
+    date "+%Y_%m_%d_%H_%M_%S"
 }
 
-mission_one_time=5
+mission_one_time=10
 do_tutorial=0
 do_invasion=1
 
 # Set the TOMCAT environment variable, assuming that the directory structure
 # mirrors that of the git repository.
-export TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
-export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
+export TOMCAT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" >/dev/null 2>&1 && pwd)"
+export TOMCAT_TMP_DIR="${TOMCAT}/tmp"
+mkdir -p "${TOMCAT_TMP_DIR}"
 
 ${TOMCAT}/tools/check_minecraft.sh
+if [[ $? -ne 0 ]]; then exit 1; fi
 
-mkdir -p "${TOMCAT_TMP_DIR}"
-if [[ $? -ne 0 ]]; then exit 1; fi;
+export tutorial_mission_log="${TOMCAT_TMP_DIR}/tutorial_mission.log"
+export zombie_invasion_log="${TOMCAT_TMP_DIR}/zombie_invasion.log"
 
-tutorial_mission_log="${TOMCAT_TMP_DIR}/tutorial_mission.log"
-zombie_invasion_log="${TOMCAT_TMP_DIR}/zombie_invasion.log"
-
-num_tries=2
+export num_tries=2
 
 if [[ ${do_tutorial} -eq 1 ]]; then
-    try=0
-    while [ $try -lt $num_tries ]; do 
-        echo " "
-        echo "Running the tutorial mission in ${TOMCAT}."
-        echo " "
-
-        ${TOMCAT}/build/bin/runExperiment --mission 0 >& ${tutorial_mission_log} &
-        bg_pid=$!
-        echo "Running: ${TOMCAT}/build/bin/runExperiment --mission 0"
-        echo "Process is $bg_pid - waiting for it"
-        wait
-        tutorial_mission_status=$?
-
-        if [[ ${tutorial_mission_status} -eq 0 ]]; then
-            tutorial_mission_status=`grep -c 'Error starting mission' ${tutorial_mission_log}`
-        fi
-
-
-        if [[ ${tutorial_mission_status} -eq 0 ]]; then
-            echo "Tutorial mission ended with success status."
-            echo " "
-            break
-        fi 
-
-        let try+=1 
-
-        if [[ $try -lt $num_tries ]]; then 
-            echo "Tutorial mission ended with failure status."
-            echo "Killing all Minecraft and Malmo processes that can be found and trying again."
-            ${TOMCAT}/tools/kill_minecraft.sh
-            ${TOMCAT}/tools/check_minecraft.sh
-        fi 
-    done
+    ${TOMCAT}/tools/run_tutorial
 fi
 
 if [[ ${do_invasion} -eq 1 ]]; then
@@ -68,14 +35,19 @@ if [[ ${do_invasion} -eq 1 ]]; then
     echo " "
 
     try=0
+
+    framerate_option=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      read -r x1 y1 width height <<< `osascript ${TOMCAT}/tools/get_minecraft_window_position_and_size.scpt | sed 's/, / /g'`
+        read -r x1 y1 width height \
+            <<<$(osascript ${TOMCAT}/tools/get_minecraft_window_position_and_size.scpt |
+                sed 's/, / /g')
+
         # On retina displays, we perform the proper scaling.
         if [[ ! -z $(system_profiler SPDisplaysDataType | grep "Retina") ]]; then
-          x1=$((2 * x1))
-          y1=$((2 * y1))
-          width=$((2 * width))
-          height=$((2 * height))
+            x1=$((2 * x1))
+            y1=$((2 * y1))
+            width=$((2 * width))
+            height=$((2 * height))
         fi
         # On macOS, we choose the avfoundation format.
         ffmpeg_fmt=avfoundation
@@ -83,77 +55,85 @@ if [[ ${do_invasion} -eq 1 ]]; then
         # explicitly for some unknown reason for the webcam recording.
         if [[ $(sysctl hw.model) == "hw.model: MacBookPro11,3" ]]; then
             framerate_option="-framerate 30"
-        else
-            framerate_option=""
         fi
-    
     else
-      ffmpeg_fmt=video4linux2
-      echo "
-    This script currently only works on MacOS since it relies on AppleScript to get
-    the position and size of the Minecraft window. Equivalent functionality can
-    probably be achieved with the wmctrl tool tool on Linux. Pull requests
-    welcome!"
-      exit 1
+        ffmpeg_fmt=video4linux2
+        echo "
+        Screen recording currently only works on MacOS since it relies on AppleScript to get
+        the position and size of the Minecraft window. Equivalent functionality can
+        probably be achieved with the wmctrl tool tool on Linux. Pull requests
+        welcome!"
+        exit 1
     fi
 
-    # Creating an output directory for this session. 
-    output_dir=${TOMCAT}/collected_data/session_`timestamp`
+    # Creating an output directory for this session.
+    output_dir=${TOMCAT}/data/participant_data/session_$(timestamp)
     mkdir -p ${output_dir}
-    ffmpeg_common_invocation="ffmpeg -y -nostdin -f $ffmpeg_fmt"
+    ffmpeg_common_invocation="ffmpeg -nostdin -f $ffmpeg_fmt"
 
     # Recording video of player's face
-    ${ffmpeg_common_invocation} ${framerate_option} -i "0:" ${output_dir}/webcam_video.mpg &> /dev/null &
+    ${ffmpeg_common_invocation} ${framerate_option} \
+        -i "0:" ${output_dir}/webcam_video.mpg &>/dev/null &
     webcam_recording_pid=$!
 
     # Recording player audio
-    ${ffmpeg_common_invocation} -i ":0" ${output_dir}/player_audio.wav &> /dev/null &
+    ${ffmpeg_common_invocation} \
+        -i ":0" ${output_dir}/player_audio.wav &>/dev/null &
     audio_recording_pid=$!
 
     # Recording game screen.
-    ${ffmpeg_common_invocation} -i "1:" -vf "crop=$width:$height:$x1:$y1" ${output_dir}/screen_video.mpg &> /dev/null &
-    screen_recording_pid=$!
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        ${ffmpeg_common_invocation} \
+            -i "1:" -vf "crop=$width:$height:$x1:$y1" ${output_dir}/screen_video.mpg \
+            &>/dev/null &
+        screen_recording_pid=$!
+    fi
 
-
-    while [ $try -lt $num_tries ]; do 
+    while [ $try -lt $num_tries ]; do
         ${TOMCAT}/build/bin/runExperiment \
-          --mission 1 \
-          --time_limit ${mission_one_time} \
-          --record_path "${output_dir}/malmo_data.tgz" \
-          &> ${zombie_invasion_log} &
+            --mission 1 \
+            --time_limit ${mission_one_time} \
+            --record_path "${output_dir}/malmo_data.tgz" \
+            &>${zombie_invasion_log} &
         bg_pid=$!
-        echo "Running: ${TOMCAT}/build/bin/runExperiment \
-          --mission 1 \
-          --time_limit ${mission_one_time} \
-          --record_path ${output_dir}/malmo_data.tgz"
-        echo "Process corresponding to ./bin/runExperiment is $bg_pid - waiting for it to complete." 
+        echo "Running: ${TOMCAT}/build/bin/runExperiment --mission 1"
+        echo "    --time_limit ${mission_one_time}"
+        echo "    --record_path ${output_dir}/malmo_data.tgz"
+        echo "Process corresponding to ./bin/runExperiment is $bg_pid"
+        echo "... waiting for it to complete."
         wait $bg_pid
         zombie_invasion_status=$?
 
         if [[ ${zombie_invasion_status} -eq 0 ]]; then
-            zombie_invasion_status=`grep -c "Error starting mission" ${zombie_invasion_log}`
+            zombie_invasion_status=$(grep -c "Error starting mission" \
+                ${zombie_invasion_log})
         fi
 
         if [[ ${zombie_invasion_status} -eq 0 ]]; then
             echo "Zombie invasion mission ended with success status."
             echo " "
             break
-        fi 
+        fi
 
-        let try+=1 
+        let try+=1
 
-        if [[ $try -lt $num_tries ]]; then 
+        if [[ $try -lt $num_tries ]]; then
             echo "Zombie invasion mission ended with failure status."
             echo "Killing all Minecraft and Malmo processes that can be found and trying again."
             ${TOMCAT}/tools/kill_minecraft.sh
             ${TOMCAT}/tools/check_minecraft.sh
-        fi 
+        fi
     done
 fi
 
 kill -2 $webcam_recording_pid
 kill -2 $audio_recording_pid
-kill -2 $screen_recording_pid
+
+# For now, screen recording works only on macOS. Need to extend it to Linux as
+# well.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    kill -2 $screen_recording_pid
+fi
 
 echo "Finished running all sessions in ${TOMCAT}."
 exit 0

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -7,7 +7,7 @@ timestamp() {
     date "+%Y_%m_%d_%H_%M_%S"
 }
 
-mission_one_time=10
+mission_one_time=600
 do_tutorial=0
 do_invasion=1
 

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -81,7 +81,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
     echo " "
 
     #Recording players face through WebCam.
-    ffmpeg -nostdin -f avfoundation -i "default" webcam_video.mpg >&/dev/null &
+    ffmpeg -nostdin -f avfoundation -i "0:0" webcam_video.mpg >&/dev/null &
     webcam_recording_pid=$!
 
     #Recording game screen.

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -7,17 +7,17 @@ timestamp() {
   date "+%Y_%m_%d_%H_%M_%S"
 }
 
-mission_one_time=60
+mission_one_time=5
 do_tutorial=0
 do_invasion=1
 
 # Set the TOMCAT environment variable, assuming that the directory structure
 # mirrors that of the git repository.
 export TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
+export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
 
 ${TOMCAT}/tools/check_minecraft.sh
 
-export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
 mkdir -p "${TOMCAT_TMP_DIR}"
 if [[ $? -ne 0 ]]; then exit 1; fi;
 
@@ -103,7 +103,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
     ffmpeg_common_invocation="ffmpeg -y -nostdin -f $ffmpeg_fmt"
 
     # Recording video of player's face
-    ${ffmpeg_common_invocation} ${framerate_option} -i "0:" ${output_dir}/webcam_video.avi &> /dev/null &
+    ${ffmpeg_common_invocation} ${framerate_option} -i "0:" ${output_dir}/webcam_video.mpg &> /dev/null &
     webcam_recording_pid=$!
 
     # Recording player audio
@@ -111,7 +111,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
     audio_recording_pid=$!
 
     # Recording game screen.
-    ${ffmpeg_common_invocation} -i "1:" -vf "crop=$width:$height:$x1:$y1" ${output_dir}/screen_video.avi &> /dev/null &
+    ${ffmpeg_common_invocation} -i "1:" -vf "crop=$width:$height:$x1:$y1" ${output_dir}/screen_video.mpg &> /dev/null &
     screen_recording_pid=$!
 
 

--- a/tools/run_tutorial
+++ b/tools/run_tutorial
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+try=0
+while [ $try -lt $num_tries ]; do 
+    echo " "
+    echo "Running the tutorial mission in ${TOMCAT}."
+    echo " "
+
+    ${TOMCAT}/build/bin/runExperiment --mission 0 \
+      --record_path=tutorial_saved_data.tgz \
+      >& ${tutorial_mission_log} &
+    bg_pid=$!
+    echo "Running: ${TOMCAT}/build/bin/runExperiment --mission 0"
+    echo "Process is $bg_pid - waiting for it"
+    wait
+    tutorial_mission_status=$?
+
+    if [[ ${tutorial_mission_status} -eq 0 ]]; then
+        tutorial_mission_status=`grep -c 'Error starting mission' ${tutorial_mission_log}`
+    fi
+
+
+    if [[ ${tutorial_mission_status} -eq 0 ]]; then
+        echo "Tutorial mission ended with success status."
+        echo " "
+        break
+    fi 
+
+    let try+=1 
+
+    if [[ $try -lt $num_tries ]]; then 
+        echo "Tutorial mission ended with failure status."
+        echo "Killing all Minecraft and Malmo processes that can be found and trying again."
+        ${TOMCAT}/tools/kill_minecraft.sh
+        ${TOMCAT}/tools/check_minecraft.sh
+    fi 
+done
+rm tutorial_saved_data.tgz


### PR DESCRIPTION
ffmpeg integration, data collection streamlining, script refactoring
================================================

This PR implements ffmpeg integration to record video of the player's face using the built-in webcam, video of the Minecraft window, and audio of the player while they are playing the game. It also streamlines data collection a bit and implements some refactoring of the scripts.

FFmpeg integration
--------------------

### Background

The three aforementioned input streams are essential for the ToMCAT research effort. Video of the player's face will be analyzed for affect, video of the Minecraft window will be used to establish human observer baselines and maybe in the service of retrospective self-report, and the audio recording will be used as input to the natural language dialogue pipeline.

In this implementation, we use ffmpeg to collect all three streams.

#### Original Malmo implementation of screen recording

Project Malmo has also implemented the functionality to record video of the Minecraft window. Basically, Minecraft sends individual RGB frames captured from the game to Malmo (see `VideoProducerImplementation.java`), that then timestamps them (with the timestamps for the frames stored in a separate text file), and then concatenates them into a video using `ffmpeg` with the `image2pipe` format (see `PosixFrameWriter.cpp`)

#### Why we are doing it differently

Turning on this feature significantly decreases the framerate at which the game runs. This is not a problem for the original envisioned purpose of Malmo - in which the 'avatars' were primarily controlled by AI agents, in the service of reinforcement learning. However, in our research, we are primarily concerned with gathering data from humans, and the reduced framerate leads to perceptible choppiness and a generally unpleasant experience for a human player.

### Caveats

In order to get a reasonable framerate for the output video of the screen recording, we focus ffmpeg on the Minecraft window, and crop out the rest of the screen. To do this, we obtain the position and size of the window using AppleScript (`tools/get_minecraft_window_position_and_size.scpt`), and process them to provide ffmpeg with the information necessary to crop the recording correctly. Of course, AppleScript is restricted to macOS machines only, so screen recording with this method has not been implemented for Linux yet. However, I believe similar functionality should be able to be achieved using the `wmctrl` tool on Linux - this is on the todo list for later.

Another caveat is that once ffmpeg has received the position and size of the Minecraft window, it will record the rectangle on the screen corresponding to that position and size. This means that if the Minecraft window is moved after this recording has started, the screen recording will not capture the whole window.

Data collection streamlining
----------------------------

The data collection process has been streamlined somewhat - now, the four data files produced in each session (player audio, player video, screen recording, Malmo data) are all placed in a timestamped directory inside the `data/participant_data` directory. The name of the directory is of the form `session_<year>_<month>_<day>_<hour>_<minute>_<second>`, corresponding to the time of creation of the directory.

Script refactoring
------------------

- Made the code that deals with setting the `TOMCAT` environment variable more concise.
- The code related to running the tutorial has been refactored out into a separate script, `run_tutorial`.

Miscellaneous
--------------

- Many .cpp, .h, and .java files have been autoformatted using `clang-format`.
- Some header include guards have been replaced with `#pragma once`.
- Some class method calls have been prefixed with `this->` to show explicitly that they are methods of the current class.
- Removed some namespace qualifiers.