### PR TITLE
Full screen ffmpeg recording

### DIFF
--- a/tools/activate_minecraft_window.scpt
+++ b/tools/activate_minecraft_window.scpt
@@ -1,0 +1,6 @@
+-- Script to bring the Minecraft window to the front and make it full screen.
+
+tell application "System Events" to tell application process "java"
+  activate
+  set value of attribute "AXFullScreen" of window 1 to true
+end tell

--- a/tools/activate_minecraft_window.scpt
+++ b/tools/activate_minecraft_window.scpt
@@ -1,6 +1,6 @@
 -- Script to bring the Minecraft window to the front and make it full screen.
 
-tell application "System Events" 
+tell application "System Events"
   click UI element "java" of list 1 of application process "Dock"
   tell application process "java"
     set value of attribute "AXFullScreen" of window 1 to true

--- a/tools/activate_minecraft_window.scpt
+++ b/tools/activate_minecraft_window.scpt
@@ -1,6 +1,8 @@
 -- Script to bring the Minecraft window to the front and make it full screen.
 
-tell application "System Events" to tell application process "java"
-  activate
-  set value of attribute "AXFullScreen" of window 1 to true
+tell application "System Events" 
+  click UI element "java" of list 1 of application process "Dock"
+  tell application process "java"
+    set value of attribute "AXFullScreen" of window 1 to true
+  end tell
 end tell

--- a/tools/get_minecraft_window_position_and_size.scpt
+++ b/tools/get_minecraft_window_position_and_size.scpt
@@ -1,8 +1,0 @@
--- Script to get the window size and position of the Minecraft window on macOS.
-
-tell application "System Events" to tell application process "java"
-  set windowposition to position of window 1
-  set windowsize to size of window 1
-end tell
-
-windowposition & windowsize

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -7,8 +7,8 @@ timestamp() {
     date "+%Y_%m_%d_%H_%M_%S"
 }
 
-mission_one_time=5
-do_tutorial=0
+mission_one_time=600
+do_tutorial=1
 do_invasion=1
 
 # Set the TOMCAT environment variable, assuming that the directory structure

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -84,8 +84,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
     # Recording game screen.
     if [[ "$OSTYPE" == "darwin"* ]]; then
         ${ffmpeg_common_invocation} \
-            -i "1:" -vf "crop=$width:$height:$x1:$y1" ${output_dir}/screen_video.mpg \
-            &>/dev/null &
+            -i "1:" -r 30 ${output_dir}/screen_video.mpg &> /dev/null &
         screen_recording_pid=$!
     fi
 

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -7,8 +7,8 @@ timestamp() {
     date "+%Y_%m_%d_%H_%M_%S"
 }
 
-mission_one_time=600
-do_tutorial=1
+mission_one_time=5
+do_tutorial=0
 do_invasion=1
 
 # Set the TOMCAT environment variable, assuming that the directory structure
@@ -38,17 +38,8 @@ if [[ ${do_invasion} -eq 1 ]]; then
 
     framerate_option=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        read -r x1 y1 width height \
-            <<<$(osascript ${TOMCAT}/tools/get_minecraft_window_position_and_size.scpt |
-                sed 's/, / /g')
+       osascript ${TOMCAT}/tools/activate_minecraft_window.scpt
 
-        # On retina displays, we perform the proper scaling.
-        if [[ ! -z $(system_profiler SPDisplaysDataType | grep "Retina") ]]; then
-            x1=$((2 * x1))
-            y1=$((2 * y1))
-            width=$((2 * width))
-            height=$((2 * height))
-        fi
         # On macOS, we choose the avfoundation format.
         ffmpeg_fmt=avfoundation
         # On a late 2013 retina MacBook Pro, we have to specify the framerate
@@ -110,6 +101,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
 
         if [[ ${zombie_invasion_status} -eq 0 ]]; then
             echo "Zombie invasion mission ended with success status."
+            echo "All recorded data is in ${output_dir}"
             echo " "
             break
         fi


### PR DESCRIPTION
Since it turns out the experiments will be conducting with Minecraft running full screen, we don't really need to crop the ffmpeg recording area after all. This PR removes the code to find out the cropping bounds and replaces it with code to bring the Minecraft window to the foreground and make it full screen.

It also adds a flag to ffmpeg to make sure that the screen recording is not choppy when full screen, but stays at 30 fps.