### PR TITLE
Discrete events 2+

### DIFF
--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistButton.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistButton.java
@@ -61,7 +61,7 @@ public class BlockAsistButton extends BlockButton {
     boolean result = super.onBlockActivated(
         worldIn, pos, state, playerIn, hand, facing, hitX, hitY, hitZ);
 
-    DiscreteEventsHelper.printEventOccurence(
+    DiscreteEventsHelper.printEventOccurrence(
         pos, playerIn, "Button Pressed"); // Used to mark discrete occurence
 
     return result;

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistLever.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistLever.java
@@ -52,7 +52,7 @@ public class BlockAsistLever extends BlockLever {
     boolean result = super.onBlockActivated(
         worldIn, pos, state, playerIn, hand, facing, hitX, hitY, hitZ);
 
-    DiscreteEventsHelper.printEventOccurence(
+    DiscreteEventsHelper.printEventOccurrence(
         pos, playerIn, getLeverEvent(pos)); // Used to mark discrete occurence
     counter++;
 

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoModClient.java
@@ -178,15 +178,17 @@ public class MalmoModClient {
     //		extraKeys.add(
     //				new InternalKey("key.toggleMalmo",
     //						28,
-    //						"key.categories.malmo") // 28 is the keycode for
-    //enter.
+    //						"key.categories.malmo") // 28 is the
+    //keycode for enter.
     //				{
     //					@Override
     //					public void onPressed() {
     //						InputType it =
-    //								(inputType != InputType.AI) ? InputType.AI :
-    //InputType.HUMAN; 						System.out.println("Toggling control between human and AI
-    //- now " + 								it); 						setInputType(it); 						super.onPressed();
+    //								(inputType != InputType.AI) ?
+    //InputType.AI : InputType.HUMAN;
+    // System.out.println("Toggling control between human and AI
+    //- now " + 								it);
+    //setInputType(it); super.onPressed();
     //					}
     //				});
 

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
@@ -40,7 +40,7 @@ import com.microsoft.Malmo.Utils.SchemaHelper;
 import com.microsoft.Malmo.Utils.ScoreHelper;
 import com.microsoft.Malmo.Utils.ScreenHelper;
 import com.microsoft.Malmo.Utils.TCPUtils;
-import edu.arizona.tomcat.Utils.TomcatForgeEventhandler;
+import edu.arizona.tomcat.Utils.TomcatForgeEventHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
@@ -114,7 +114,7 @@ public class MalmoMod {
   public void preInit(FMLPreInitializationEvent event) {
 
     MinecraftForge.EVENT_BUS.register(
-        new TomcatForgeEventhandler()); // Registering this here so it's
+        new TomcatForgeEventHandler()); // Registering this here so it's
                                         // accessible outside missions.
 
     ModBlocks.init();

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
@@ -16,136 +16,146 @@ import java.util.Date;
 import java.util.Map;
 
 /**
- * This class holds static methods to print the discrete events. It writes the output
- * to saves/discrete_events/Discrete_Events.json
+ * This class holds static methods to print the discrete events. It writes the
+ * output to saves/discrete_events/Discrete_Events.json
  */
 public class DiscreteEventsHelper {
 
-    private static final String DISCRETE_EVENT_REPORTS_FOLDER = "saves/discrete_events";
+  private static final String DISCRETE_EVENT_REPORTS_FOLDER =
+      "saves/discrete_events";
+  private static int counter = 0;
 
-    /**
-     * When called, this method will print the occurence of the event to the
-     * terminal. The Blockpos passed is the coordinate at which the event
-     * was triggered, and the playerIn is the player who triggered the event.
-     *
-     * @param pos      - Position of event
-     * @param playerIn -  The player who triggered the event
-     */
-    public static void
-    printEventOccurence(BlockPos pos, EntityPlayer playerIn, String event) {
-        String coordinates = createCoordinateString(pos);
+  /**
+   * When called, this method will print the occurrence of the event to the
+   * terminal. The BlockPos passed is the coordinate at which the event
+   * was triggered, and the playerIn is the player who triggered the event.
+   *
+   * @param pos      - Position of event
+   * @param playerIn -  The player who triggered the event
+   */
+  public static void
+  printEventOccurrence(BlockPos pos, EntityPlayer playerIn, String event) {
+    String coordinates = createCoordinateString(pos);
 
-        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-        Date date = new Date();
-        String dateTime = dateFormat.format(date); // Date and Time
+    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+    Date date = new Date();
+    String dateTime = dateFormat.format(date); // Date and Time
 
-        Map<String, String> output = new LinkedTreeMap<String, String>();
+    Map<String, String> output = new LinkedTreeMap<String, String>();
 
-        output.put("Event Type", event);
-        output.put("Event caused by", playerIn.getDisplayNameString());
-        output.put("Event Coordinates", coordinates);
-        output.put("Occurrence Time", dateTime);
+    output.put("Event Type", event);
+    output.put("Event caused by", playerIn.getDisplayNameString());
+    output.put("Event Coordinates", coordinates);
+    output.put("Occurrence Time", dateTime);
 
-        saveDiscreteEventReport(output);
+    saveDiscreteEventReport(output);
+  }
+
+  /**
+   * When called, this method will print the occurrence of an attack event to
+   * the terminal. The details of the attack event consist of who the player was
+   * and who they attacked. The method can figure out whether an attack killed
+   * the enemy.
+   *
+   * @param pos      - Position of event
+   * @param playerIn -  The player who triggered the event
+   */
+  public static void printAttackEventOccurrence(BlockPos pos,
+                                                Entity enemy,
+                                                EntityPlayer playerIn) {
+
+    String playerName = playerIn.getDisplayNameString();
+    String enemyName = enemy.getName();
+
+    String event = playerName + " killed " + enemyName;
+    if (enemy.isEntityAlive()) {
+      event = playerName + " attacked " + enemyName;
     }
 
-    /**
-     * When called, this method will print the occurrence of an attack event to
-     * the terminal. The details of the attack event consist of who the player was
-     * and who they attacked. The method can figure out whether an attack killed
-     * the enemy.
-     *
-     * @param pos      - Position of event
-     * @param playerIn -  The player who triggered the event
-     */
-    public static void
-    printAttackEventOccurence(BlockPos pos, Entity enemy, EntityPlayer playerIn) {
+    String coordinates = createCoordinateString(pos);
 
-        String playerName = playerIn.getDisplayNameString();
-        String enemyName = enemy.getName();
+    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+    Date date = new Date();
+    String dateTime = dateFormat.format(date); // Date and Time
 
-        String event = playerName + " killed " + enemyName;
-        if (enemy.isEntityAlive()) {
-            event = playerName + " attacked " + enemyName;
-        }
+    Map<String, String> output = new LinkedTreeMap<String, String>();
 
-        String coordinates = createCoordinateString(pos);
+    output.put("Event Type", event);
+    output.put("Event caused by", playerName);
+    output.put("Event Coordinates", coordinates);
+    output.put("Occurrence Time", dateTime);
 
-        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-        Date date = new Date();
-        String dateTime = dateFormat.format(date); // Date and Time
+    saveDiscreteEventReport(output);
+  }
 
-        Map<String, String> output = new LinkedTreeMap<String, String>();
+  /**
+   * Returns the position information as a String.
+   *
+   * @param pos - The coordinates as a BlockPos
+   * @return A String representation
+   */
+  private static String createCoordinateString(BlockPos pos) {
+    int x = pos.getX(), y = pos.getY(), z = pos.getZ(); // event coordinates
+    String coordinates = "X: " + x + " "
+                         + "Y: " + y + " "
+                         + "Z: " + z;
+    return coordinates;
+  }
 
-        output.put("Event Type", event);
-        output.put("Event caused by", playerName);
-        output.put("Event Coordinates", coordinates);
-        output.put("Occurrence Time", dateTime);
+  /**
+   * Calls the necessary methods to save the discrete event report
+   * passed as a Java Map to the Discrete_Events.json file.
+   *
+   * @param mapReport - The event report
+   */
+  private static void saveDiscreteEventReport(Map<String, String> mapReport) {
+    createDiscreteEventsFolder();
+    String path = getDiscreteEventstPath();
+    writeDiscreteEventsToFile(path, mapReport);
+    counter++;
+  }
 
-        saveDiscreteEventReport(output);
+  /**
+   * Creates discrete_events folder if it doesn't exist already
+   */
+  private static void createDiscreteEventsFolder() {
+    File folder = new File(DISCRETE_EVENT_REPORTS_FOLDER);
+    if (!folder.exists()) {
+      folder.mkdir();
     }
+  }
 
-    /**
-     * Returns the position information as a String.
-     *
-     * @param pos - The coordinates as a BlockPos
-     * @return A String representation
-     */
-    private static String createCoordinateString(BlockPos pos) {
-        int x = pos.getX(), y = pos.getY(), z = pos.getZ(); // event coordinates
-        String coordinates = "X: " + x + " "
-                + "Y: " + y + " "
-                + "Z: " + z;
-        return coordinates;
+  /**
+   * All discrete events are written to the path returned by this method.
+   * Currently, discrete event occurrences are appended onto the same file.
+   */
+  private static String getDiscreteEventstPath() {
+    String path = DISCRETE_EVENT_REPORTS_FOLDER + "/Discrete_Events.json";
+    return path;
+  }
+
+  /**
+   * Writes output to .json file.
+   *
+   * @param path      - The filepath where the event is to be appended.
+   * @param mapReport - The event report.
+   */
+  private static void writeDiscreteEventsToFile(String path,
+                                                Map<String, String> mapReport) {
+    try {
+      if (counter % 2 == 0) {
+        FileWriter fileWriter = new FileWriter(path, true);
+        Gson gson = new GsonBuilder().create();
+        String json = gson.toJson(mapReport) + "\n\n";
+        fileWriter.write(json);
+        fileWriter.close();
+      }
+      else {
+        ;
+      }
     }
-
-    /**
-     * Calls the necessary methods to save the discrete evnt report
-     * passed as a Java Map to the Discrete_Events.json file.
-     *
-     * @param mapReport - The event report
-     */
-    private static void saveDiscreteEventReport(Map<String, String> mapReport) {
-        createDiscreteEventsFolder();
-        String path = getDiscreteEventstPath();
-        writeDiscreteEventsToFile(path, mapReport);
-
+    catch (IOException e) {
+      e.printStackTrace();
     }
-
-    /**
-     * Creates discrete_events folder if it doesn't exist already
-     */
-    private static void createDiscreteEventsFolder() {
-        File folder = new File(DISCRETE_EVENT_REPORTS_FOLDER);
-        if (!folder.exists()) {
-            folder.mkdir();
-        }
-    }
-
-    /**
-     * All discrete events are written to the path returned by this method.
-     * Currently, discrete event occurrences are appended onto the same file.
-     */
-    private static String getDiscreteEventstPath() {
-        String path = DISCRETE_EVENT_REPORTS_FOLDER + "/Discrete_Events.json";
-        return path;
-    }
-
-    /**
-     * Writes output to .json file.
-     *
-     * @param path      - The filepath where the event is to be appended.
-     * @param mapReport - The event report.
-     */
-    private static void writeDiscreteEventsToFile(String path, Map<String, String> mapReport) {
-        try {
-            FileWriter fileWriter = new FileWriter(path, true);
-            Gson gson = new GsonBuilder().create();
-            String json = gson.toJson(mapReport)+"\n\n";
-            fileWriter.write(json);
-            fileWriter.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+  }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
@@ -1,110 +1,151 @@
 package edu.arizona.tomcat.Utils;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.internal.LinkedTreeMap;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 
 /**
- * This class holds static methods to print the discrete events. It currently
- * prints the output to terminal.
+ * This class holds static methods to print the discrete events. It writes the output
+ * to saves/discrete_events/Discrete_Events.json
  */
 public class DiscreteEventsHelper {
 
-  /**
-   * When called, this method will print the occurence of the event to the
-   * terminal. The Blockpos passed is the coordinate at which the event
-   * was triggered, and the playerIn is the player who triggered the event.
-   *
-   * @param pos      - Position of event
-   * @param playerIn -  The player who triggered the event
-   */
-  public static void
-  printEventOccurence(BlockPos pos, EntityPlayer playerIn, String event) {
-    String coordinates = createCoordinateString(pos);
+    private static final String DISCRETE_EVENT_REPORTS_FOLDER = "saves/discrete_events";
 
-    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-    Date date = new Date();
-    String dateTime = dateFormat.format(date); // Date and Time
+    /**
+     * When called, this method will print the occurence of the event to the
+     * terminal. The Blockpos passed is the coordinate at which the event
+     * was triggered, and the playerIn is the player who triggered the event.
+     *
+     * @param pos      - Position of event
+     * @param playerIn -  The player who triggered the event
+     */
+    public static void
+    printEventOccurence(BlockPos pos, EntityPlayer playerIn, String event) {
+        String coordinates = createCoordinateString(pos);
 
-    Map<String, String> output = new LinkedTreeMap<String, String>();
+        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+        Date date = new Date();
+        String dateTime = dateFormat.format(date); // Date and Time
 
-    output.put("Event Type", event);
-    output.put("Event caused by", playerIn.getDisplayNameString());
-    output.put("Event Coordinates", coordinates);
-    output.put("Occurence Time", dateTime);
+        Map<String, String> output = new LinkedTreeMap<String, String>();
 
-    // The output is placed in a map above. The code below is only for temporary
-    // printing to terminal.
+        output.put("Event Type", event);
+        output.put("Event caused by", playerIn.getDisplayNameString());
+        output.put("Event Coordinates", coordinates);
+        output.put("Occurrence Time", dateTime);
 
-    System.out.println("+---EVENT REPORT---+");
-    for (String key : output.keySet()) {
-      System.out.println(key + ": " + output.get(key));
-    }
-    System.out.println();
-    System.out.println();
-  }
-
-  /**
-   * When called, this method will print the occurrence of an attack event to
-   * the terminal. The details of the attack event consist of who the player was
-   * and who they attacked. The method can figure out whether an attack killed
-   * the enemy.
-   *
-   * @param pos      - Position of event
-   * @param playerIn -  The player who triggered the event
-   */
-  public static void
-  printAttackEventOccurence(BlockPos pos, Entity enemy, EntityPlayer playerIn) {
-
-    String playerName = playerIn.getDisplayNameString();
-    String enemyName = enemy.getName();
-
-    String event = playerName + " killed " + enemyName;
-    if (enemy.isEntityAlive()) {
-      event = playerName + " attacked " + enemyName;
+        saveDiscreteEventReport(output);
     }
 
-    String coordinates = createCoordinateString(pos);
+    /**
+     * When called, this method will print the occurrence of an attack event to
+     * the terminal. The details of the attack event consist of who the player was
+     * and who they attacked. The method can figure out whether an attack killed
+     * the enemy.
+     *
+     * @param pos      - Position of event
+     * @param playerIn -  The player who triggered the event
+     */
+    public static void
+    printAttackEventOccurence(BlockPos pos, Entity enemy, EntityPlayer playerIn) {
 
-    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-    Date date = new Date();
-    String dateTime = dateFormat.format(date); // Date and Time
+        String playerName = playerIn.getDisplayNameString();
+        String enemyName = enemy.getName();
 
-    Map<String, String> output = new LinkedTreeMap<String, String>();
+        String event = playerName + " killed " + enemyName;
+        if (enemy.isEntityAlive()) {
+            event = playerName + " attacked " + enemyName;
+        }
 
-    output.put("Event Type", event);
-    output.put("Event caused by", playerName);
-    output.put("Event Coordinates", coordinates);
-    output.put("Occurence Time", dateTime);
+        String coordinates = createCoordinateString(pos);
 
-    // The output is placed in a map above. The code below is only for temporary
-    // printing to terminal.
+        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+        Date date = new Date();
+        String dateTime = dateFormat.format(date); // Date and Time
 
-    System.out.println("+---EVENT REPORT---+");
-    for (String key : output.keySet()) {
-      System.out.println(key + ": " + output.get(key));
+        Map<String, String> output = new LinkedTreeMap<String, String>();
+
+        output.put("Event Type", event);
+        output.put("Event caused by", playerName);
+        output.put("Event Coordinates", coordinates);
+        output.put("Occurrence Time", dateTime);
+
+        saveDiscreteEventReport(output);
     }
-    System.out.println();
-    System.out.println();
-  }
 
-  /**
-   * Returns the position information as a String.
-   *
-   * @param pos - The coordinates as a BlockPos
-   * @return A String representation
-   */
-  private static String createCoordinateString(BlockPos pos) {
-    int x = pos.getX(), y = pos.getY(), z = pos.getZ(); // event coordinates
-    String coordinates = "X: " + x + " "
-                         + "Y: " + y + " "
-                         + "Z: " + z;
-    return coordinates;
-  }
+    /**
+     * Returns the position information as a String.
+     *
+     * @param pos - The coordinates as a BlockPos
+     * @return A String representation
+     */
+    private static String createCoordinateString(BlockPos pos) {
+        int x = pos.getX(), y = pos.getY(), z = pos.getZ(); // event coordinates
+        String coordinates = "X: " + x + " "
+                + "Y: " + y + " "
+                + "Z: " + z;
+        return coordinates;
+    }
+
+    /**
+     * Calls the necessary methods to save the discrete evnt report
+     * passed as a Java Map to the Discrete_Events.json file.
+     *
+     * @param mapReport - The event report
+     */
+    private static void saveDiscreteEventReport(Map<String, String> mapReport) {
+        createDiscreteEventsFolder();
+        String path = getDiscreteEventstPath();
+        writeDiscreteEventsToFile(path, mapReport);
+
+    }
+
+    /**
+     * Creates discrete_events folder if it doesn't exist already
+     */
+    private static void createDiscreteEventsFolder() {
+        File folder = new File(DISCRETE_EVENT_REPORTS_FOLDER);
+        if (!folder.exists()) {
+            folder.mkdir();
+        }
+    }
+
+    /**
+     * All discrete events are written to the path returned by this method.
+     * Currently, discrete event occurrences are appended onto the same file.
+     */
+    private static String getDiscreteEventstPath() {
+        String path = DISCRETE_EVENT_REPORTS_FOLDER + "/Discrete_Events.json";
+        return path;
+    }
+
+    /**
+     * Writes output to .json file.
+     *
+     * @param path      - The filepath where the event is to be appended.
+     * @param mapReport - The event report.
+     */
+    private static void writeDiscreteEventsToFile(String path, Map<String, String> mapReport) {
+        try {
+            FileWriter fileWriter = new FileWriter(path, true);
+            Gson gson = new GsonBuilder().create();
+            String json = gson.toJson(mapReport)+"\n\n";
+            fileWriter.write(json);
+            fileWriter.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
@@ -130,7 +130,7 @@ public class DiscreteEventsHelper {
    * Currently, discrete event occurrences are appended onto the same file.
    */
   private static String getDiscreteEventstPath() {
-    String path = DISCRETE_EVENT_REPORTS_FOLDER + "/Discrete_Events.json";
+    String path = DISCRETE_EVENT_REPORTS_FOLDER + "/discrete_events.json";
     return path;
   }
 

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/TomcatForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/TomcatForgeEventHandler.java
@@ -6,7 +6,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-public class TomcatForgeEventhandler {
+public class TomcatForgeEventHandler {
 
   /**
    * This event is triggered when the player attacks an enemy. It passes
@@ -24,6 +24,6 @@ public class TomcatForgeEventhandler {
         event.getTarget().posY,
         event.getTarget().posZ); // Event occurrence is location of target
 
-    DiscreteEventsHelper.printAttackEventOccurence(pos, enemy, playerIn);
+    DiscreteEventsHelper.printAttackEventOccurrence(pos, enemy, playerIn);
   }
 }

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/blockstates/asist_button.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/blockstates/asist_button.json
@@ -1,0 +1,16 @@
+{
+    "variants": {
+        "facing=up,powered=false":    { "model": "malmomod:asist_button", "uvlock": true },
+        "facing=down,powered=false":  { "model": "malmomod:asist_button", "uvlock": true, "x": 180 },
+        "facing=east,powered=false":  { "model": "malmomod:asist_button", "uvlock": true, "x": 90, "y": 90 },
+        "facing=west,powered=false":  { "model": "malmomod:asist_button", "uvlock": true, "x": 90, "y": 270 },
+        "facing=south,powered=false": { "model": "malmomod:asist_button", "uvlock": true, "x": 90, "y": 180 },
+        "facing=north,powered=false": { "model": "malmomod:asist_button", "uvlock": true, "x": 90 },
+        "facing=up,powered=true":     { "model": "malmomod:asist_button_pressed", "uvlock": true },
+        "facing=down,powered=true":   { "model": "malmomod:asist_button_pressed", "uvlock": true, "x": 180 },
+        "facing=east,powered=true":   { "model": "malmomod:asist_button_pressed", "uvlock": true, "x": 90, "y": 90 },
+        "facing=west,powered=true":   { "model": "malmomod:asist_button_pressed", "uvlock": true, "x": 90, "y": 270 },
+        "facing=south,powered=true":  { "model": "malmomod:asist_button_pressed", "uvlock": true, "x": 90, "y": 180 },
+        "facing=north,powered=true":  { "model": "malmomod:asist_button_pressed", "uvlock": true, "x": 90 }
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/blockstates/asist_lever.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/blockstates/asist_lever.json
@@ -1,0 +1,20 @@
+{
+    "variants": {
+        "facing=down_z,powered=false": { "model": "malmomod:asist_lever_off", "x": 180, "y": 180 },
+        "facing=down_x,powered=false": { "model": "malmomod:asist_lever_off", "x": 180, "y": 90 },
+        "facing=up_z,powered=false": { "model": "malmomod:asist_lever_off" },
+        "facing=up_x,powered=false": { "model": "malmomod:asist_lever_off", "y": 270 },
+        "facing=east,powered=false": { "model": "malmomod:asist_lever_off", "x": 90, "y": 90 },
+        "facing=west,powered=false": { "model": "malmomod:asist_lever_off", "x": 90, "y": 270 },
+        "facing=south,powered=false" : { "model": "malmomod:asist_lever_off", "x": 90, "y": 180 },
+        "facing=north,powered=false" : { "model": "malmomod:asist_lever_off", "x": 90 },
+        "facing=down_z,powered=true" : { "model": "malmomod:asist_lever", "x": 180, "y": 180 },
+        "facing=down_x,powered=true" : { "model": "malmomod:asist_lever", "x": 180, "y": 90 },
+        "facing=up_z,powered=true": { "model": "malmomod:asist_lever" },
+        "facing=up_x,powered=true": { "model": "malmomod:asist_lever", "y": 270 },
+        "facing=east,powered=true": { "model": "malmomod:asist_lever", "x": 90, "y": 90 },
+        "facing=west,powered=true": { "model": "malmomod:asist_lever", "x": 90, "y": 270 },
+        "facing=south,powered=true": { "model": "malmomod:asist_lever", "x": 90, "y": 180 },
+        "facing=north,powered=true": { "model": "malmomod:asist_lever", "x": 90 }
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_button.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_button.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/button",
+    "textures": {
+        "texture": "blocks/stone"
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_button_inventory.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_button_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/button_inventory",
+    "textures": {
+        "texture": "blocks/stone"
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_button_pressed.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_button_pressed.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/button_pressed",
+    "textures": {
+        "texture": "blocks/stone"
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_lever.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_lever.json
@@ -1,0 +1,33 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "blocks/cobblestone",
+        "base": "blocks/cobblestone",
+        "lever": "blocks/lever"
+    },
+    "elements": [
+        {   "from": [ 5, 0, 4 ],
+            "to": [ 11, 3, 12 ],
+            "faces": {
+                "down":  { "uv": [ 5, 4, 11, 12 ], "texture": "#base" },
+                "up":    { "uv": [ 5, 4, 11, 12 ], "texture": "#base" },
+                "north": { "uv": [ 5, 0, 11,  3 ], "texture": "#base" },
+                "south": { "uv": [ 5, 0, 11,  3 ], "texture": "#base" },
+                "west":  { "uv": [ 4, 0, 12,  3 ], "texture": "#base" },
+                "east":  { "uv": [ 4, 0, 12,  3 ], "texture": "#base" }
+            }
+        },
+        {   "from": [ 7, 1, 7 ],
+            "to": [ 9, 11, 9 ],
+            "rotation": { "origin": [ 8, 1, 8 ], "axis": "x", "angle": -45 },
+            "faces": {
+                "down":  { "uv": [ 7, 6, 9,  8 ], "texture": "#lever" },
+                "up":    { "uv": [ 7, 6, 9,  8 ], "texture": "#lever" },
+                "north": { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" },
+                "south": { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" },
+                "west":  { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" },
+                "east":  { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" }
+            }
+        }
+    ]
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_lever_off.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_lever_off.json
@@ -1,0 +1,33 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "blocks/cobblestone",
+        "base": "blocks/cobblestone",
+        "lever": "blocks/lever"
+    },
+    "elements": [
+        {   "from": [ 5, 0, 4 ],
+            "to": [ 11, 3, 12 ],
+            "faces": {
+                "down":  { "uv": [ 5, 4, 11, 12 ], "texture": "#base" },
+                "up":    { "uv": [ 5, 4, 11, 12 ], "texture": "#base" },
+                "north": { "uv": [ 5, 0, 11,  3 ], "texture": "#base" },
+                "south": { "uv": [ 5, 0, 11,  3 ], "texture": "#base" },
+                "west":  { "uv": [ 4, 0, 12,  3 ], "texture": "#base" },
+                "east":  { "uv": [ 4, 0, 12,  3 ], "texture": "#base" }
+            }
+        },
+        {   "from": [ 7, 1, 7 ],
+            "to": [ 9, 11, 9 ],
+            "rotation": { "origin": [ 8, 1, 8 ], "axis": "x", "angle": 45 },
+            "faces": {
+                "down":  { "uv": [ 7, 6, 9,  8 ], "texture": "#lever" },
+                "up":    { "uv": [ 7, 6, 9,  8 ], "texture": "#lever" },
+                "north": { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" },
+                "south": { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" },
+                "west":  { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" },
+                "east":  { "uv": [ 7, 6, 9, 16 ], "texture": "#lever" }
+            }
+        }
+    ]
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/item/asist_button.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/item/asist_button.json
@@ -1,0 +1,3 @@
+{
+    "parent": "malmomod:block/asist_button_inventory"
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/item/asist_lever.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/item/asist_lever.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "blocks/lever"
+    }
+}

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -29,6 +29,8 @@ if [[ ${do_tutorial} -eq 1 ]]; then
     ${TOMCAT}/tools/run_tutorial
 fi
 
+rm -f ${TOMCAT}/external/malmo/Minecraft/run/saves/discrete_events/discrete_events.json
+
 if [[ ${do_invasion} -eq 1 ]]; then
     echo " "
     echo "Running the Zombie invasion mission in ${TOMCAT}."
@@ -124,6 +126,8 @@ kill -2 $audio_recording_pid
 if [[ "$OSTYPE" == "darwin"* ]]; then
     kill -2 $screen_recording_pid
 fi
+
+mv ${TOMCAT}/external/malmo/Minecraft/run/saves/discrete_events/discrete_events.json ${output_dir}/discrete_events.json 
 
 echo "Finished running all sessions in ${TOMCAT}."
 exit 0


### PR DESCRIPTION
This PR does a few small things:

1) Textures have been added for both the `Asist Button` and `Asist Lever`. They look like the Minecraft stone button and lever.
Fixes #69 

2) The output for discrete events is now appended to a file called `Discrete_Events.json` in the 
`Minecraft/run/saves/discrete_events` directory. There is only one file created each time because each event log holds time data.

Note: Technically, the methods that output the event log are called twice - once by the server and once by the client. I was unable to separate these calls, so each method is called twice in succession. The `DiscreteEventsHelper` uses a counter to disregard every other call, which results in each event log only being written once to the JSON file. 
This would need to be tested once the client and server have been separated since it is a workaround.