### PR TITLE
Improvements to installation and session running scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 project(tomcat)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/")

--- a/docs/beginner_setup_instructions.md
+++ b/docs/beginner_setup_instructions.md
@@ -37,3 +37,9 @@ password you use to install any software on your computer). You will not see
 any letters appearing as you type in your password - they will be hidden for
 privacy - so it is fine if it appears blank. Just type in your password
 normally and press the enter/return key on your keyboard.
+
+When you run the `run_session.sh` script, you might be asked to give the
+terminal permissions to control system events - this is so that the script can
+automatically make the Minecraft window full screen. Additionally, you might be
+asked for permissions to use the microphone and webcam - this is for recording
+audio and video of the player when the mission is running.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,6 +43,16 @@ This folder will contain four files:
 - `malmo_data.tgz` : A gzipped tarball containing Malmo data about player's
   position, nearby entities, etc.
 
+
+To interrupt the game and quit at any time, press the `Esc` key, then click on
+the terminal window where you ran the `run_session.sh` script, and then
+interrupt the process with `Ctrl+C`. Then, run the following command to shut
+down Minecraft.
+
+```
+./tools/kill_minecraft.sh
+```
+
 ## For developers
 
 To speed up builds, create a file called gradle.properties and add

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -27,7 +27,7 @@ pushd "${TOMCAT}"
 
     # Trying to set the correct version of Java.
     macports_found=`[ -x "$(command -v port)" ]; echo $?`
-    if [[ $macports_found -eq 1 ]]; then
+    if [[ $macports_found -eq 0 ]]; then
       export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk8/Contents/Home
     fi
     pushd build > /dev/null 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -36,22 +36,21 @@ pushd "${TOMCAT}"
                             -DBOOST_ROOT=$BOOST_ROOT_1_69_0
             if [[ $? -ne 0 ]]; then exit 1; fi;
         else
-            cmake ${TOMCAT}
-            if [[ $? -ne 0 ]]; then exit 1; fi;
+            if ! cmake ${TOMCAT}; then exit 1; fi
         fi;
 
-        make -j
-        if [[ $? -ne 0 ]]; then exit 1; fi;
+        if ! make -j; then exit 1; fi
 
         make -j Minecraft
     popd > /dev/null 
 popd > /dev/null 
 
-${TOMCAT}/tools/download_tomcat_worlds.sh
-if [[ $? -ne 0 ]]; then exit 1; fi;
+if ! ${TOMCAT}/tools/download_tomcat_worlds.sh; then exit 1; fi
 
-#${TOMCAT}/tools/download_OpenFace_models.sh
-#if [[ $? -ne 0 ]]; then exit 1; fi;
+
+if [[ ! -d ${TOMCAT}/data/OpenFace_models ]]; then
+  if ! ${TOMCAT}/tools/download_OpenFace_models.sh; then exit 1; fi
+fi
 
 echo " "
 echo "Finished installing ToMCAT in ${TOMCAT}!"

--- a/tools/install_boost_from_source.sh
+++ b/tools/install_boost_from_source.sh
@@ -2,15 +2,17 @@
 
 # Install Boost from source
 
-curl -O https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+boost_minor_version=71
+curl -O\
+  https://dl.bintray.com/boostorg/release/1."${boost_minor_version}".0/source/boost_1_"${boost_minor_version}"_0.tar.gz
 if [[ $? -ne 0 ]]; then exit 1; fi;
-tar xfz boost_1_71_0.tar.gz
+tar xfz boost_1_"${boost_minor_version}"_0.tar.gz
 if [[ $? -ne 0 ]]; then exit 1; fi;
-pushd boost_1_71_0
+pushd boost_1_"${boost_minor_version}"_0
   ./bootstrap.sh
   if [[ $? -ne 0 ]]; then exit 1; fi;
   sudo ./b2 install
   if [[ $? -ne 0 ]]; then exit 1; fi;
 popd
-rm -rf boost_1_71_0*
+/bin/rm -rf boost_1_"${boost_minor_version}"_0*
 exit 0

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -2,7 +2,8 @@
 
 # Set the TOMCAT environment variable, assuming that the directory structure
 # mirrors that of the git repository.
-export TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
+TOMCAT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
+export TOMCAT
 
 echo "Installing ToMCAT dependencies."
 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -15,7 +15,7 @@ install_macports() {
     make -j
     sudo make -j install
   popd > /dev/null
-  rm -rf Macports-$version*
+  /bin/rm -rf Macports-$version*
 }
 
 install_dependencies_using_macports() {
@@ -45,7 +45,7 @@ install_dependencies_using_macports() {
   # port points to Java 1.8.0_242, which is incompatible with Malmo (the
   # local Portfile points to Java 1.8.0_232.
   pushd ${TOMCAT}/tools/local-ports/openjdk8 > /dev/null
-    sudo port install
+    if ! sudo port install; then exit 1; fi
   popd > /dev/null
 }
 
@@ -85,18 +85,6 @@ install_dependencies_using_homebrew() {
   fi;
 
   #TODO When OpenFace is reintroduced, add dlib installation back here.
-}
-
-download_and_extract_dlib() {
-  pushd "${TOMCAT}/external"
-    # We download a specific commit snapshot of dlib from Github that
-    # contains a fix for the latest version of OpenCV that is being
-    # installed by Homebrew.
-    commit_sha=471c3d30e181a40942177a4358aa0496273d2108
-    curl -L https://github.com/davisking/dlib/archive/${commit_sha}.zip -o dlib.zip
-    unzip dlib.zip
-    mv dlib-${commit_sha} dlib
-  popd
 }
 
 echo "Checking OS."

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -28,7 +28,7 @@ mkdir -p "${TOMCAT_TMP_DIR}"
 
 # Trying to set the correct version of Java.
 macports_found=`[ -x "$(command -v port)" ]; echo $?`
-if [[ $macports_found -eq 1 ]]; then
+if [[ $macports_found -eq 0 ]]; then
   export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk8/Contents/Home
 fi
 

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -39,6 +39,8 @@ export zombie_invasion_log="${TOMCAT_TMP_DIR}/zombie_invasion.log"
 
 export num_tries=2
 
+osascript "${TOMCAT}"/tools/activate_minecraft_window.scpt
+
 if [[ ${do_tutorial} -eq 1 ]]; then 
   "${TOMCAT}"/tools/run_tutorial
 fi
@@ -54,7 +56,6 @@ if [[ ${do_invasion} -eq 1 ]]; then
 
     framerate_option=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        osascript "${TOMCAT}"/tools/activate_minecraft_window.scpt
 
         # On macOS, we choose the avfoundation format.
         ffmpeg_fmt=avfoundation

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -39,7 +39,9 @@ export zombie_invasion_log="${TOMCAT_TMP_DIR}/zombie_invasion.log"
 
 export num_tries=2
 
-osascript "${TOMCAT}"/tools/activate_minecraft_window.scpt
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  osascript "${TOMCAT}"/tools/activate_minecraft_window.scpt
+fi
 
 if [[ ${do_tutorial} -eq 1 ]]; then 
   "${TOMCAT}"/tools/run_tutorial


### PR DESCRIPTION
- Scripts have been updated so that CMakeLists.txt requires an exact Java version (1.8), and if MacPorts has been used to install openjdk8, then the build will detect that version of Java even if there are other Java versions on the system.
- Added a couple more places where the return code is checked, scripts are more consistent about declaring and assigning separately (https://github.com/koalaman/shellcheck/wiki/SC2155)
- `rm` has been replaced by `/bin/rm` to avoid conflicts with aliases
- `CMakeLists.txt` enforces the C++17 standard.
- `docs/beginner_setup_instructions.md` now includes explanations of giving the terminal permission to control system events, webcam, and microphone.
- `docs/installation.md` updated to include instructions for how to quit the mission and exit the game.
- Tutorial is now full screen as well.