### PR TITLE
Discrete events 3 - Hit-Control Door Open Event and Health Measurement

### DIFF
--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistIron.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistIron.java
@@ -1,0 +1,39 @@
+package com.microsoft.Malmo.ASISTBlocks;
+
+import edu.arizona.tomcat.Utils.DiscreteEventsHelper;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockAir;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class BlockAsistAir extends BlockAir {
+
+    public BlockAsistAir() {
+
+        setUnlocalizedName("ASIST_Air_Block");
+        setRegistryName(
+                "ASIST_Air_Block"); // The name Minecraft sees. Also used in en_US.lang
+
+        this.setCreativeTab(
+                CreativeTabs.REDSTONE); // shows up in redstone tab in creative mode
+    }
+
+    @Override
+    /**
+     * Called by ItemBlocks after a block is set in the world, to allow post-place logic
+     */
+    public void onBlockPlacedBy(World worldIn, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack)
+    {
+        DiscreteEventsHelper.printEventOccurrence(
+                pos, null, "Hit-Controlled Door Opened"); // Used to mark discrete occurrence
+    }
+
+
+
+}

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistIron.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistIron.java
@@ -13,13 +13,13 @@ import java.util.List;
 
 /**
  * This block will be used as the "door" block for the Hit-Controlled doors.
- * This block will write its event to the file when it is destroyed.
+ * The block will write its event to the file when it is destroyed.
  * <p>
- * This block is set to drop nothing when it is destroyed, hence giving the
+ * It is set to drop nothing when it is destroyed, hence giving the
  * illusion of vanishing. Replacing this block with the /setblock command
  * inside Minecraft without the "destroy" add-on will result in no output.
  * <p>
- * It will NOT write any output if the player destroys the block by hand because
+ * It will also NOT write any output if the player destroys the block by hand because
  * we don't expect the player to do that.
  */
 public class BlockAsistIron extends Block {
@@ -47,6 +47,7 @@ public class BlockAsistIron extends Block {
    */
   public List<ItemStack>
   getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
+
     // Technically a command block destroys this, so we aren't identifying a
     // player as destroying this block for the sake of the code.
     DiscreteEventsHelper.printEventOccurrence(

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistIron.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/BlockAsistIron.java
@@ -2,38 +2,58 @@ package com.microsoft.Malmo.ASISTBlocks;
 
 import edu.arizona.tomcat.Utils.DiscreteEventsHelper;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockAir;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.IBlockAccess;
 
-public class BlockAsistAir extends BlockAir {
+import java.util.List;
 
-    public BlockAsistAir() {
+/**
+ * This block will be used as the "door" block for the Hit-Controlled doors.
+ * This block will write its event to the file when it is destroyed.
+ * <p>
+ * This block is set to drop nothing when it is destroyed, hence giving the
+ * illusion of vanishing. Replacing this block with the /setblock command
+ * inside Minecraft without the "destroy" add-on will result in no output.
+ * <p>
+ * It will NOT write any output if the player destroys the block by hand because
+ * we don't expect the player to do that.
+ */
+public class BlockAsistIron extends Block {
 
-        setUnlocalizedName("ASIST_Air_Block");
-        setRegistryName(
-                "ASIST_Air_Block"); // The name Minecraft sees. Also used in en_US.lang
+  public BlockAsistIron() {
 
-        this.setCreativeTab(
-                CreativeTabs.REDSTONE); // shows up in redstone tab in creative mode
-    }
+    super(Material.IRON);
+    setUnlocalizedName("ASIST_Iron_Block");
+    setRegistryName(
+        "ASIST_Iron_Block"); // The name Minecraft sees. Also used in en_US.lang
 
-    @Override
-    /**
-     * Called by ItemBlocks after a block is set in the world, to allow post-place logic
-     */
-    public void onBlockPlacedBy(World worldIn, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack)
-    {
-        DiscreteEventsHelper.printEventOccurrence(
-                pos, null, "Hit-Controlled Door Opened"); // Used to mark discrete occurrence
-    }
+    this.setCreativeTab(
+        CreativeTabs.REDSTONE); // shows up in redstone tab in creative mode
+  }
 
+  @Override
+  /**
+   * This returns a complete list of items dropped from this block.
+   *
+   * @param world The current world
+   * @param pos Block position in world
+   * @param state Current state
+   * @param fortune Breakers fortune level
+   * @return A ArrayList containing all items this block drops
+   */
+  public List<ItemStack>
+  getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
+    // Technically a command block destroys this, so we aren't identifying a
+    // player as destroying this block for the sake of the code.
+    DiscreteEventsHelper.printEventOccurrence(
+        pos,
+        null,
+        "Hit-Controlled Door Opened"); // Used to mark discrete occurrence
 
-
+    return new java.util.ArrayList<ItemStack>(); // Drop nothing
+  }
 }

--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/ModBlocks.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/ASISTBlocks/ModBlocks.java
@@ -26,6 +26,7 @@ public class ModBlocks {
 
   public static Block asistButtonBlock;
   public static Block asistLeverBlock;
+  public static Block asistIronBlock;
 
   /**
    * This method initializes the new block created.
@@ -33,6 +34,7 @@ public class ModBlocks {
   public static void init() {
     asistButtonBlock = new BlockAsistButton();
     asistLeverBlock = new BlockAsistLever();
+    asistIronBlock = new BlockAsistIron();
   }
 
   /**
@@ -43,6 +45,7 @@ public class ModBlocks {
   public static void register() {
     registerBlock(asistButtonBlock);
     registerBlock(asistLeverBlock);
+    registerBlock(asistIronBlock);
 
     // Add copied lines under this if necessary
   }
@@ -71,6 +74,7 @@ public class ModBlocks {
   public static void registerRenders() {
     registerRender(asistButtonBlock);
     registerRender(asistLeverBlock);
+    registerRender(asistIronBlock);
 
     // Add copied lines under this if necessary
   }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
@@ -44,7 +44,7 @@ public class DiscreteEventsHelper {
     Map<String, String> output = new LinkedTreeMap<String, String>();
 
     output.put("Event Type", event);
-    if(playerIn != null) {
+    if (playerIn != null) {
       output.put("Event caused by", playerIn.getDisplayNameString());
     }
     output.put("Event Coordinates", coordinates);
@@ -71,7 +71,8 @@ public class DiscreteEventsHelper {
     String enemyName = enemy.getName();
 
     String event = playerName + " killed " + enemyName;
-    String enemyHealth = "0.0" + "/" + enemy.getMaxHealth();
+    String enemyHealth = "0.0"
+                         + "/" + enemy.getMaxHealth();
     if (enemy.isEntityAlive()) {
       event = playerName + " attacked " + enemyName;
       enemyHealth = enemy.getHealth() + "/" + enemy.getMaxHealth();

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/DiscreteEventsHelper.java
@@ -3,6 +3,10 @@ package edu.arizona.tomcat.Utils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.internal.LinkedTreeMap;
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -10,9 +14,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.math.BlockPos;
 
 /**
  * This class holds static methods to print the discrete events. It writes the
@@ -43,7 +44,9 @@ public class DiscreteEventsHelper {
     Map<String, String> output = new LinkedTreeMap<String, String>();
 
     output.put("Event Type", event);
-    output.put("Event caused by", playerIn.getDisplayNameString());
+    if(playerIn != null) {
+      output.put("Event caused by", playerIn.getDisplayNameString());
+    }
     output.put("Event Coordinates", coordinates);
     output.put("Occurrence Time", dateTime);
 
@@ -60,15 +63,18 @@ public class DiscreteEventsHelper {
    * @param playerIn -  The player who triggered the event
    */
   public static void printAttackEventOccurrence(BlockPos pos,
-                                                Entity enemy,
+                                                EntityMob enemy,
                                                 EntityPlayer playerIn) {
 
     String playerName = playerIn.getDisplayNameString();
+    String playerHealth = playerIn.getHealth() + "/" + playerIn.getMaxHealth();
     String enemyName = enemy.getName();
 
     String event = playerName + " killed " + enemyName;
+    String enemyHealth = "0.0" + "/" + enemy.getMaxHealth();
     if (enemy.isEntityAlive()) {
       event = playerName + " attacked " + enemyName;
+      enemyHealth = enemy.getHealth() + "/" + enemy.getMaxHealth();
     }
 
     String coordinates = createCoordinateString(pos);
@@ -80,6 +86,8 @@ public class DiscreteEventsHelper {
     Map<String, String> output = new LinkedTreeMap<String, String>();
 
     output.put("Event Type", event);
+    output.put("Current Enemy Health", enemyHealth);
+    output.put("Current Player Health", playerHealth);
     output.put("Event caused by", playerName);
     output.put("Event Coordinates", coordinates);
     output.put("Occurrence Time", dateTime);

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/TomcatForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/TomcatForgeEventHandler.java
@@ -1,6 +1,7 @@
 package edu.arizona.tomcat.Utils;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
@@ -17,13 +18,18 @@ public class TomcatForgeEventHandler {
   @SubscribeEvent
   public void attackEnemy(AttackEntityEvent event) {
     EntityPlayer playerIn = event.getEntityPlayer();
-    Entity enemy = event.getTarget();
+    Entity target = event.getTarget();
 
-    BlockPos pos = new BlockPos(
-        event.getTarget().posX,
-        event.getTarget().posY,
-        event.getTarget().posZ); // Event occurrence is location of target
+    if(target instanceof EntityMob) {
 
-    DiscreteEventsHelper.printAttackEventOccurrence(pos, enemy, playerIn);
+      EntityMob enemy = (EntityMob) target;
+
+      BlockPos pos = new BlockPos(
+              event.getTarget().posX,
+              event.getTarget().posY,
+              event.getTarget().posZ); // Event occurrence is location of target
+
+      DiscreteEventsHelper.printAttackEventOccurrence(pos, enemy, playerIn);
+    }
   }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/TomcatForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Utils/TomcatForgeEventHandler.java
@@ -20,14 +20,14 @@ public class TomcatForgeEventHandler {
     EntityPlayer playerIn = event.getEntityPlayer();
     Entity target = event.getTarget();
 
-    if(target instanceof EntityMob) {
+    if (target instanceof EntityMob) {
 
-      EntityMob enemy = (EntityMob) target;
+      EntityMob enemy = (EntityMob)target;
 
       BlockPos pos = new BlockPos(
-              event.getTarget().posX,
-              event.getTarget().posY,
-              event.getTarget().posZ); // Event occurrence is location of target
+          event.getTarget().posX,
+          event.getTarget().posY,
+          event.getTarget().posZ); // Event occurrence is location of target
 
       DiscreteEventsHelper.printAttackEventOccurrence(pos, enemy, playerIn);
     }

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/blockstates/asist_iron_block.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/blockstates/asist_iron_block.json
@@ -1,0 +1,5 @@
+{
+    "variants": {
+        "normal": { "model": "malmomod:asist_iron_block" }
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/lang/en_US.lang
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/lang/en_US.lang
@@ -11,4 +11,5 @@ auth.usernameToPasswordMappings=Map usernames to passwords in format <username>:
 
 tile.ASIST_Button.name=ASIST Button
 tile.ASIST_Lever.name=ASIST Lever
+tile.ASIST_Iron_Block.name=ASIST Iron Block
 

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_iron_block.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/block/asist_iron_block.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "blocks/iron_block"
+    }
+}

--- a/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/item/asist_iron_block.json
+++ b/external/malmo/Minecraft/src/main/resources/assets/malmomod/models/item/asist_iron_block.json
@@ -1,0 +1,3 @@
+{
+    "parent": "malmomod:block/asist_iron_block"
+}


### PR DESCRIPTION
This PR implements two things:

1) A new block called `Asist Iron Block` has been created to replace the `Iron Block` being used in the Hit-Controlled Doors. These blocks write an output saying "Hit-Controlled Door Opened" when it is destroyed through a command (not by a player since the player never directly breaks it). 

2) The Attack Entity Event now uses a subclass of `Entity` called `EntityMob` when looking for target data, so it can measure the current enemy health each time the event is fired. This is reported as current health/max health. The same has been done for the player as well.

Outputs are written to the same `discrete_events.json` file.