### PR TITLE
Observations & Self-reports

### DIFF
--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Mission.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Mission.java
@@ -535,13 +535,10 @@ public abstract class Mission implements FeedbackListener, PhaseListener {
    * Get the filename for a given self-report based on some of its info
    */
   private String getSelfReportPath(MissionSelfReport selfReport) {
-    DateFormat dateFormat = new SimpleDateFormat("yyyy_MM_dd_hh_mm_ss_a");
     String path =
-        String.format("%s/%d_%s_%s.json",
-                      SELF_REPORT_FOLDER,
-                      selfReport.getMissionID(),
-                      selfReport.getPlayerID(),
-                      dateFormat.format(selfReport.getMissionStartTime()));
+        String.format("%s/self_report_player_%s.json",
+                      SELF_REPORT_FOLDER,                      
+                      selfReport.getPlayerID());
     return path;
   }
 

--- a/tools/run_session.sh
+++ b/tools/run_session.sh
@@ -101,6 +101,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
             "${TOMCAT}"/build/bin/runExperiment \
             --mission external/malmo/sample_missions/default_flat_1.xml\
             --time_limit ${time_limit} \
+            --record_observations \
             --record_path "${output_dir}"/malmo_data.tgz \
             &>"${zombie_invasion_log}" &
             bg_pid=$!
@@ -108,6 +109,7 @@ if [[ ${do_invasion} -eq 1 ]]; then
             "${TOMCAT}"/build/bin/runExperiment \
             --mission 1 \
             --time_limit ${time_limit} \
+            --record_observations \
             --record_path "${output_dir}"/malmo_data.tgz \
             &>"${zombie_invasion_log}" &
             bg_pid=$!
@@ -158,9 +160,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 discrete_actions_file="${TOMCAT}"/external/malmo/Minecraft/run/saves/discrete_events/discrete_events.json
+
 if [[ -f "${discrete_actions_file}" ]]; then
   mv "${discrete_actions_file}" "${output_dir}"/discrete_events.json
 fi
+
+# Move the self-reports from the Minecraft folder to the participant data folder
+mv "${TOMCAT}"/external/malmo/Minecraft/run/saves/self_reports/* "${output_dir}"
 
 echo "Finished running all sessions in ${TOMCAT}".
 exit 0


### PR DESCRIPTION
This branch solves the following problems:

1. Observations were not being collected. Its was missing the flag --record_observations in the call to the runExperiment script inside the run_session script.
2. Self-reports are now being moved to the participant_data folder in the end of the mission. 