### PR TITLE
Adding #include <stack> to VideoFrameWriter.h

### DIFF
--- a/external/malmo/Malmo/src/VideoFrameWriter.h
+++ b/external/malmo/Malmo/src/VideoFrameWriter.h
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <queue>
 #include <string>
+#include <stack>
 
 namespace malmo {
   class IFrameWriter {


### PR DESCRIPTION
This PR fixes a compilation error with GCC 7.5.0 on Ubuntu 18.04.