### PR TITLE
Bumping minimum Boost version to 1.69

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
     "-- fmt package not found on system, please install it.  (https://fmt.dev)")
 endif()
 
-find_package(Boost 1.67
+find_package(Boost 1.69
              COMPONENTS chrono
                         date_time
                         filesystem

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ cd tomcat && ./tools/install.sh
 ```
 
 For people using other operating systems, note that ToMCAT
-depends on the following: CMake 3.12+, Boost 1.65+, a C++17 compatible
+depends on the following: CMake 3.12+, Boost 1.69+, a C++17 compatible
 compiler (tested with GCC 9 and AppleClang 11.0 so far), libfmt, doxygen,
 ffmpeg, OpenCV, dlib, Java 8, and Gradle. You can inspect the script
 `tools/install_dependencies.sh` to see what exactly is being installed and how.

--- a/external/malmo/CMakeLists.txt
+++ b/external/malmo/CMakeLists.txt
@@ -57,7 +57,7 @@ set(INCLUDE_PYTHON
     OFF
     CACHE BOOL ${INCLUDE_PYTHON_DESC})
 
-find_package(Boost 1.67
+find_package(Boost 1.69
              COMPONENTS chrono
                         date_time
                         filesystem


### PR DESCRIPTION
This PR increments the minimum version of Boost required to 1.69 to fix a compilation error on some macOS machines.

See also: https://github.com/boostorg/atomic/issues/15