### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/src/Mission.cpp
+++ b/src/Mission.cpp
@@ -101,13 +101,13 @@ namespace tomcat {
         Mission::id_to_world_folder_map.at(stoi(this->mission_id_or_path));
 
     string world_dir_path =
-        format("{}data/worlds/{}", getenv("TOMCAT"), world_dir);
+        format("{}/data/worlds/{}", getenv("TOMCAT"), world_dir);
 
     if (!fs::exists(fs::path(world_dir_path))) {
       throw TomcatMissionException(
           format("Requested world directory {} not found.\n"
                  "Please download the world files by executing the "
-                 "{}tools/download/tomcat_worlds script.\n"
+                 "{}/tools/download/tomcat_worlds script.\n"
                  "Note: The world file for mission ID 2 (USAR Singleplayer) is "
                  "currently only available to teams participating in DARPA's "
                  "ASIST program.",

--- a/tools/configure_session
+++ b/tools/configure_session
@@ -40,7 +40,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
     if [ ! "${GITHUB_ACTIONS:-false}" = "true" ]; then
       echo "Checking if webcam video recording works..."
-      "${TOMCAT}"/tools/macos/test_webcam
+      . "${TOMCAT}"/tools/macos/test_webcam
 
       if (( "${ENABLE_SYSTEM_AUDIO_RECORDING:-1}" )); then
         echo "Checking if system audio recording is set up..."

--- a/tools/macos/test_system_audio_recording
+++ b/tools/macos/test_system_audio_recording
@@ -4,7 +4,6 @@ set -u
 
 # Script to test if system audio recording is enabled.
 
-export original_output_device=$(SwitchAudioSource -c)
 blackhole_is_setup=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep "\[0\] BlackHole 16ch")
 if [[ $blackhole_is_setup == "" ]]; then
   echo "BlackHole system audio recording virtual output device is not set up."

--- a/tools/macos/test_system_audio_recording
+++ b/tools/macos/test_system_audio_recording
@@ -4,6 +4,7 @@ set -u
 
 # Script to test if system audio recording is enabled.
 
+export original_output_device=$(SwitchAudioSource -c)
 blackhole_is_setup=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep "\[0\] BlackHole 16ch")
 if [[ $blackhole_is_setup == "" ]]; then
   echo "BlackHole system audio recording virtual output device is not set up."

--- a/tools/macos/test_system_audio_recording
+++ b/tools/macos/test_system_audio_recording
@@ -4,8 +4,9 @@ set -u
 
 # Script to test if system audio recording is enabled.
 
-blackhole_is_setup=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep "\[0\] BlackHole 16ch")
-if [[ $blackhole_is_setup == "" ]]; then
+blackhole_is_setup=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep "BlackHole 16ch")
+multi_device_output_is_setup=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep "Multi-Device Output")
+if [[ $blackhole_is_setup == "" || "$multi_device_output_is_setup" == "" ]]; then
   echo "BlackHole system audio recording virtual output device is not set up."
   echo "We will do it now."
   if ! "$TOMCAT"/tools/macos/activate_system_audio_recording; then exit 1; fi

--- a/tools/macos/test_webcam
+++ b/tools/macos/test_webcam
@@ -30,8 +30,6 @@ test_webcam_macos() {
     elif [[ ! $framerate_err == "" ]]; then
       # On recent MacBook Pros, it seems that we have to specify the framerate
       # explicitly for some unknown reason for the webcam recording.
-      echo "Caught unsupported framerate error:" $framerate_err
-      echo "We will now set the framerate to 30 going forward."
       export framerate_option="-framerate 30"
       test_webcam_macos
     else
@@ -45,4 +43,3 @@ test_webcam_macos() {
 }
 
 test_webcam_macos
-exit 0

--- a/tools/macos/test_webcam
+++ b/tools/macos/test_webcam
@@ -32,7 +32,7 @@ test_webcam_macos() {
       # explicitly for some unknown reason for the webcam recording.
       echo "Caught unsupported framerate error:" $framerate_err
       echo "We will now set the framerate to 30 going forward."
-      framerate_option="-framerate 30"
+      export framerate_option="-framerate 30"
       test_webcam_macos
     else
       echo "Unable to capture webcam video - unhandled ffmpeg error."

--- a/tools/run_session
+++ b/tools/run_session
@@ -86,7 +86,7 @@ cleanup() {
       if (( "${ENABLE_SYSTEM_AUDIO_RECORDING:-1}" )); then
         # Switching the audio output from the multi-output device to the
         # built-in output.
-        if ! SwitchAudioSource -s "$original_output_device"; then exit 1; fi
+        if ! SwitchAudioSource -s "${original_output_device:-}"; then exit 1; fi
       fi
     fi
   fi

--- a/tools/run_session
+++ b/tools/run_session
@@ -86,7 +86,7 @@ cleanup() {
       if (( "${ENABLE_SYSTEM_AUDIO_RECORDING:-1}" )); then
         # Switching the audio output from the multi-output device to the
         # built-in output.
-        if ! SwitchAudioSource -s "Built-in Output"; then exit 1; fi
+        if ! SwitchAudioSource -s "$original_output_device"; then exit 1; fi
       fi
     fi
   fi

--- a/tools/run_session
+++ b/tools/run_session
@@ -34,6 +34,9 @@ timestamp() {
 output_dir="${TOMCAT}"/data/participant_data/session_$(timestamp)
 mkdir -p "${output_dir}"
 
+
+export original_output_device=$(SwitchAudioSource -c)
+
 . "$TOMCAT"/tools/configure_session
 if [[ $? -ne 0 ]]; then exit 1; fi
 
@@ -86,7 +89,7 @@ cleanup() {
       if (( "${ENABLE_SYSTEM_AUDIO_RECORDING:-1}" )); then
         # Switching the audio output from the multi-output device to the
         # built-in output.
-        if ! SwitchAudioSource -s "${original_output_device:-}"; then exit 1; fi
+        if ! SwitchAudioSource -s "${original_output_device}"; then exit 1; fi
       fi
     fi
   fi

--- a/tools/run_session
+++ b/tools/run_session
@@ -46,14 +46,14 @@ start_ffmpeg_recording() {
     -f ${ffmpeg_fmt_webcam}\
     ${framerate_option:-}\
     -i ${ffmpeg_input_device_webcam}\
-    "${output_dir}"/webcam_video.mpg &> /dev/null &
+    "${output_dir}"/webcam_video.mpg &> ${TOMCAT_TMP_DIR}/ffmpeg_webcam_main.log &
   
   echo "Recording player audio using microphone."
   ffmpeg\
     -nostdin\
     -f ${ffmpeg_fmt_microphone}\
     -i ${ffmpeg_input_device_microphone}\
-    "${output_dir}"/player_audio.wav &> /dev/null &
+    "${output_dir}"/player_audio.wav &> ${TOMCAT_TMP_DIR}/ffmpeg_microphone_main.log &
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if (( "${ENABLE_SYSTEM_AUDIO_RECORDING:-1}" )); then

--- a/tools/run_tutorial
+++ b/tools/run_tutorial
@@ -7,8 +7,7 @@ while [ $try -lt $num_tries ]; do
     echo " "
 
     ${TOMCAT}/build/bin/runExperiment --mission 0 \
-      --record_path=tutorial_saved_data.tgz \
-      >& ${tutorial_mission_log} &
+      2> ${tutorial_mission_log} > /dev/null &
     bg_pid=$!
     echo "Running: ${TOMCAT}/build/bin/runExperiment --mission 0"
     echo "Process is $bg_pid - waiting for it"


### PR DESCRIPTION
This PR implements

- Fixes to the scripts to make them work with MacBook Pros that have the framerate issue (where we need to specify a framerate of 30 for the webcam).
- Adds a slash to the tomcat directory in `src/Mission.cpp` - it caused an error on Savannah's computer.
- Removes the kind of scary framerate error message in the scripts - the script just handles the error now.
- Separate error logs are created for the microphone and webcam for the main mission (vs the tests).
- Tutorial mission outputs are redirected to `/dev/null` and the `--record_path` option has been removed from the `run_tutorial` script.