### PR TITLE
Additional events: Lever flip, door open, block break, left click

### DIFF
--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
@@ -12,7 +12,7 @@ public class BlockBreakEvent extends Event {
     private String blockType;
     private String blockMaterial;
 
-    /** A constructor for general block interaction events. */
+    /** A constructor for general block breaking events. */
     public BlockBreakEvent(BlockEvent.BreakEvent event) {
         this.playerName = event.getPlayer().getDisplayNameString();
         BlockPos pos = event.getPos();

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
@@ -10,21 +10,14 @@ public class BlockBreakEvent extends Event {
     private String playerName;
     private Position blockPosition;
     private String blockType;
-
-    protected IBlockState getBlockState(BlockEvent.BreakEvent event) {
-        return event.getWorld().getBlockState(event.getPos());
-    }
-
-    protected Block getBlock(BlockEvent.BreakEvent event) {
-        return this.getBlockState(event).getBlock();
-    }
-
+    private String blockMaterial;
 
     /** A constructor for general block interaction events. */
     public BlockBreakEvent(BlockEvent.BreakEvent event) {
         this.playerName = event.getPlayer().getDisplayNameString();
         BlockPos pos = event.getPos();
         this.blockPosition = new Position(pos);
-        this.blockType = this.getBlock(event).getClass().getName();
+        this.blockType = event.getState().getBlock().getClass().getName();
+        this.blockMaterial = event.getState().getBlock().getRegistryName().toString();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
@@ -3,27 +3,26 @@ package edu.arizona.tomcat.Events;
 import edu.arizona.tomcat.World.Position;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.block.state.IBlockState;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import com.google.gson.annotations.Expose;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraft.block.Block;
 
-public class BlockInteraction extends Event {
+public class BlockBreakEvent extends Event {
     private String playerName;
     private Position blockPosition;
     private String blockType;
 
-    protected IBlockState getBlockState(PlayerInteractEvent event) {
+    protected IBlockState getBlockState(BlockEvent.BreakEvent event) {
         return event.getWorld().getBlockState(event.getPos());
     }
 
-    protected Block getBlock(PlayerInteractEvent event) {
+    protected Block getBlock(BlockEvent.BreakEvent event) {
         return this.getBlockState(event).getBlock();
     }
 
 
     /** A constructor for general block interaction events. */
-    public BlockInteraction(PlayerInteractEvent event) {
-        this.playerName = event.getEntityPlayer().getDisplayNameString();
+    public BlockBreakEvent(BlockEvent.BreakEvent event) {
+        this.playerName = event.getPlayer().getDisplayNameString();
         BlockPos pos = event.getPos();
         this.blockPosition = new Position(pos);
         this.blockType = this.getBlock(event).getClass().getName();

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
@@ -4,11 +4,16 @@ import edu.arizona.tomcat.World.Position;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import com.google.gson.annotations.Expose;
+import net.minecraft.block.Block;
 
 public class BlockInteraction extends Event {
     private String playerName = null;
     private Position blockPosition;
-    private String blockType = "";
+    private String blockType;
+
+    @Expose(serialize=false)
+    protected Block block;
 
     /** A constructor for general block interaction events. */
     public BlockInteraction(PlayerInteractEvent.RightClickBlock event) {
@@ -17,7 +22,7 @@ public class BlockInteraction extends Event {
         BlockPos pos = event.getPos();
         this.playerName = event.getEntityPlayer().getDisplayNameString();
         this.blockPosition = new Position(pos);
-        this.blockType =
-            world.getBlockState(pos).getBlock().getClass().getName();
+        this.block = world.getBlockState(pos).getBlock();
+        this.blockType = this.block.getClass().getName();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
@@ -2,6 +2,7 @@ package edu.arizona.tomcat.Events;
 
 import edu.arizona.tomcat.World.Position;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.block.state.IBlockState;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import com.google.gson.annotations.Expose;
 import net.minecraft.block.Block;
@@ -11,16 +12,16 @@ public class BlockInteraction extends Event {
     private Position blockPosition;
     private String blockType;
 
-    @Expose(serialize=false)
-    protected Block block;
+    protected IBlockState getBlockState(PlayerInteractEvent.RightClickBlock event) {
+        return event.getWorld().getBlockState(event.getPos());
+    }
 
     protected Block getBlock(PlayerInteractEvent.RightClickBlock event) {
-        return event.getWorld().getBlockState(event.getPos()).getBlock();
+        return this.getBlockState(event).getBlock();
     }
 
     /** A constructor for general block interaction events. */
     public BlockInteraction(PlayerInteractEvent.RightClickBlock event) {
-        this.eventType = "block_interaction";
         this.playerName = event.getEntityPlayer().getDisplayNameString();
         BlockPos pos = event.getPos();
         this.blockPosition = new Position(pos);

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
@@ -4,13 +4,14 @@ import edu.arizona.tomcat.World.Position;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.block.state.IBlockState;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import com.google.gson.annotations.Expose;
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.Block;
 
 public class BlockInteraction extends Event {
     private String playerName;
     private Position blockPosition;
     private String blockType;
+    private String blockMaterial;
 
     protected IBlockState getBlockState(PlayerInteractEvent event) {
         return event.getWorld().getBlockState(event.getPos());
@@ -21,11 +22,13 @@ public class BlockInteraction extends Event {
     }
 
 
+
     /** A constructor for general block interaction events. */
     public BlockInteraction(PlayerInteractEvent event) {
         this.playerName = event.getEntityPlayer().getDisplayNameString();
         BlockPos pos = event.getPos();
         this.blockPosition = new Position(pos);
         this.blockType = this.getBlock(event).getClass().getName();
+        this.blockMaterial = this.getBlock(event).getRegistryName().toString();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
@@ -2,27 +2,28 @@ package edu.arizona.tomcat.Events;
 
 import edu.arizona.tomcat.World.Position;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import com.google.gson.annotations.Expose;
 import net.minecraft.block.Block;
 
 public class BlockInteraction extends Event {
-    private String playerName = null;
+    private String playerName;
     private Position blockPosition;
     private String blockType;
 
     @Expose(serialize=false)
     protected Block block;
 
+    protected Block getBlock(PlayerInteractEvent.RightClickBlock event) {
+        return event.getWorld().getBlockState(event.getPos()).getBlock();
+    }
+
     /** A constructor for general block interaction events. */
     public BlockInteraction(PlayerInteractEvent.RightClickBlock event) {
         this.eventType = "block_interaction";
-        World world = event.getWorld();
-        BlockPos pos = event.getPos();
         this.playerName = event.getEntityPlayer().getDisplayNameString();
+        BlockPos pos = event.getPos();
         this.blockPosition = new Position(pos);
-        this.block = world.getBlockState(pos).getBlock();
-        this.blockType = this.block.getClass().getName();
+        this.blockType = this.getBlock(event).getClass().getName();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/DoorInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/DoorInteraction.java
@@ -1,0 +1,19 @@
+package edu.arizona.tomcat.Events;
+
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.BlockDoor;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraft.block.Block;
+
+public class DoorInteraction extends BlockInteraction {
+
+    /** Returns true if the lever was originally on (prior to the player
+     * right-clicking it), and false otherwise. */
+    private Boolean wasOpen;
+
+    /** A constructor for door opening/closing events. */
+    public DoorInteraction(PlayerInteractEvent event) {
+        super(event);
+        this.wasOpen = BlockDoor.isOpen(event.getWorld(), event.getPos());
+    }
+}

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/DoorInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/DoorInteraction.java
@@ -7,7 +7,7 @@ import net.minecraft.block.Block;
 
 public class DoorInteraction extends BlockInteraction {
 
-    /** Returns true if the lever was originally on (prior to the player
+    /** Returns true if the door was originally open (prior to the player
      * right-clicking it), and false otherwise. */
     private Boolean wasOpen;
 

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/EntityDeath.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/EntityDeath.java
@@ -11,8 +11,6 @@ public class EntityDeath extends Event {
     private UUID entityId;
 
     public EntityDeath(LivingDeathEvent event) {
-        this.eventType = "entity_death";
-
         Entity entity = event.getEntity();
         this.entityId = entity.getUniqueID();
         this.entityName = entity.getName();

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/Event.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/Event.java
@@ -2,7 +2,10 @@ package edu.arizona.tomcat.Events;
 import edu.arizona.tomcat.Utils.TimeStamper;
 
 public class Event {
+    private String eventType; 
     private String timestamp;
-    protected String eventType = "event";
-    public Event() { this.timestamp = TimeStamper.getTimeStamp(); }
+    public Event() {
+        this.eventType = this.getClass().getName();
+        this.timestamp = TimeStamper.getTimeStamp();
+    }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
@@ -3,6 +3,10 @@ package edu.arizona.tomcat.Events;
 import edu.arizona.tomcat.Messaging.MqttService;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.block.BlockLever;
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -13,6 +17,10 @@ import net.minecraftforge.fml.relauncher.Side;
 public class ForgeEventHandler {
 
     private FMLCommonHandler fmlCommonHandler = FMLCommonHandler.instance();
+
+    private Block getBlock(PlayerInteractEvent.RightClickBlock event) {
+        return event.getWorld().getBlockState(event.getPos()).getBlock();
+    }
 
     /** Instance of the MqttService singleton to use for publishing messages. */
     private MqttService mqttService = MqttService.getInstance();
@@ -54,8 +62,15 @@ public class ForgeEventHandler {
     @SubscribeEvent
     public void handle(PlayerInteractEvent.RightClickBlock event) {
         if (!event.getWorld().isRemote) {
-            this.mqttService.publish(new BlockInteraction(event),
-                                     "observations/events/block_interaction");
+            Block block = this.getBlock(event);
+            if (block instanceof BlockLever) {
+                this.mqttService.publish(new LeverFlip(event),
+                        "observations/events/block_interaction/lever_flip");
+            }
+            else {
+                this.mqttService.publish(new BlockInteraction(event),
+                                         "observations/events/block_interaction");
+            }
         }
     }
 

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
@@ -5,9 +5,11 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.block.BlockLever;
+import net.minecraft.block.BlockDoor;
 import net.minecraft.block.Block;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -57,7 +59,7 @@ public class ForgeEventHandler {
 
     /**
      * Handle events from Forge event bus triggered by players right-clicking a
-     * block, publish events to MQTT message bus with type 'block_interaction'.
+     * block, publish events to MQTT message bus.
      */
     @SubscribeEvent
     public void handle(PlayerInteractEvent.RightClickBlock event) {
@@ -65,12 +67,40 @@ public class ForgeEventHandler {
             Block block = this.getBlock(event);
             if (block instanceof BlockLever) {
                 this.mqttService.publish(new LeverFlip(event),
-                        "observations/events/block_interaction/lever_flip");
+                        "observations/events/player_interactions/right_clicks/blocks/lever");
             }
+            else if (block instanceof BlockDoor) {
+                this.mqttService.publish(new DoorInteraction(event),
+                        "observations/events/player_interactions/right_clicks/blocks/door");
+            }
+
             else {
                 this.mqttService.publish(new BlockInteraction(event),
-                                         "observations/events/block_interaction");
+                                         "observations/events/player_interactions/right_clicks/blocks");
             }
+        }
+    }
+
+    /**
+     * Handle events from Forge event bus triggered by players left-clicking a
+     * block, publish events to MQTT message bus.
+     */
+    @SubscribeEvent
+    public void handle(PlayerInteractEvent.LeftClickBlock event) {
+        if (!event.getWorld().isRemote) {
+            this.mqttService.publish(new BlockInteraction(event),
+                                     "observations/events/player_interactions/left_clicks/blocks");
+        }
+    }
+
+    /**
+     * Handle events from Forge event bus triggered by players breaking blocks.
+     */
+    @SubscribeEvent
+    public void handle(BlockEvent.BreakEvent event) {
+        if (!event.getWorld().isRemote) {
+            this.mqttService.publish(new BlockBreakEvent(event),
+                                     "observations/events/player_interactions/break_events/blocks");
         }
     }
 

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/IronDoorOpened.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/IronDoorOpened.java
@@ -9,6 +9,5 @@ public class IronDoorOpened extends Event {
     /** Constructor for use with the BlockAsistIron class. */
     public IronDoorOpened(BlockPos pos) {
         this.doorPosition = new Position(pos);
-        this.eventType = "iron_door_opened";
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
@@ -7,13 +7,13 @@ import net.minecraft.block.Block;
 
 public class LeverFlip extends BlockInteraction {
 
-    /** Returns true if the lever is powered, false otherwise. */
+    /** Returns true if the lever was originally on (prior to the player
+     * right-clicking it), and false otherwise. */
     private Boolean powered;
 
     /** A constructor for lever flipping events. */
     public LeverFlip(PlayerInteractEvent.RightClickBlock event) {
         super(event);
-        this.eventType = this.getClass().getName();
-        this.powered = this.getBlock(event).getBlockState().getBaseState().getValue(BlockLever.POWERED);
+        this.powered = this.getBlockState(event).getValue(BlockLever.POWERED);
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
@@ -1,0 +1,19 @@
+package edu.arizona.tomcat.Events;
+
+import edu.arizona.tomcat.World.Position;
+import edu.arizona.tomcat.Events.BlockInteraction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraft.block.properties.PropertyBool;
+
+public class LeverFlip extends BlockInteraction {
+    /** A constructor for general block interaction events. */
+    private PropertyBool powered;
+
+    protected LeverFlip(PlayerInteractEvent.RightClickBlock event) {
+        super(event);
+        this.eventType = this.getClass().getName();
+        this.powered = this.block.blockState.getValue(POWERED).booleanValue();
+    }
+}

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
@@ -1,19 +1,19 @@
 package edu.arizona.tomcat.Events;
 
-import edu.arizona.tomcat.World.Position;
-import edu.arizona.tomcat.Events.BlockInteraction;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.BlockLever;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraft.block.Block;
 
 public class LeverFlip extends BlockInteraction {
-    /** A constructor for general block interaction events. */
-    private PropertyBool powered;
 
-    protected LeverFlip(PlayerInteractEvent.RightClickBlock event) {
+    /** Returns true if the lever is powered, false otherwise. */
+    private Boolean powered;
+
+    /** A constructor for lever flipping events. */
+    public LeverFlip(PlayerInteractEvent.RightClickBlock event) {
         super(event);
         this.eventType = this.getClass().getName();
-        this.powered = this.block.blockState.getValue(POWERED).booleanValue();
+        this.powered = this.getBlock(event).getBlockState().getBaseState().getValue(BlockLever.POWERED);
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
@@ -7,13 +7,13 @@ import net.minecraft.block.Block;
 
 public class LeverFlip extends BlockInteraction {
 
-    /** Returns true if the lever was originally on (prior to the player
+    /** Returns true if the lever was originally powered (prior to the player
      * right-clicking it), and false otherwise. */
-    private Boolean powered;
+    private Boolean wasPowered;
 
     /** A constructor for lever flipping events. */
     public LeverFlip(PlayerInteractEvent.RightClickBlock event) {
         super(event);
-        this.powered = this.getBlockState(event).getValue(BlockLever.POWERED);
+        this.wasPowered = this.getBlockState(event).getValue(BlockLever.POWERED);
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/MobAttacked.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/MobAttacked.java
@@ -25,7 +25,6 @@ public class MobAttacked extends Event {
 
     public MobAttacked(AttackEntityEvent event) {
         EntityMob target = (EntityMob)event.getTarget();
-        this.eventType = "mob_attacked";
         EntityPlayer player = event.getEntityPlayer();
         this.playerName = player.getDisplayNameString();
         this.targetType = target.getClass().getName();


### PR DESCRIPTION
Additional events: Lever flip, door open, block break, left clicks
=============================================

This PR implements a few additional events: lever flips, door opening, block breaking, and left clicking - to support the USAR single player mission.

A new field, `block_material` has been added to the data structure, and the `event_type` field now reflects the fully-qualified name of the corresponding event class (to accurately capture hypernymy relations between event types).

Examples
----------

### Block interaction

Event representing a block interaction (will be dispatched to different message bus topics depending on whether it was a left click or right click).

```json
{
    "player_name": "tomcat",
    "block_position": {
        "x": -2183.0,
        "y": 53.0,
        "z": 177.0
    },
    "block_type": "net.minecraft.block.BlockButtonStone",
    "block_material": "minecraft:stone_button",
    "event_type": "edu.arizona.tomcat.Events.BlockInteraction",
    "timestamp": "2020-04-26T23:11:22:515Z"
}
```

### Door interaction

The initial state of the door (i.e. before the player right-clicks on it) is captured with the `was_open` boolean field.

```json
{
    "was_open": false,
    "player_name": "tomcat",
    "block_position": {
        "x": -2153.0,
        "y": 53.0,
        "z": 176.0
    },
    "block_type": "net.minecraft.block.BlockDoor",
    "block_material": "minecraft:wooden_door",
    "event_type": "edu.arizona.tomcat.Events.DoorInteraction",
    "timestamp": "2020-04-26T23:11:28:560Z"
}
```

### Lever flip

The `was_powered` boolean field gives the state of the lever just before the player right-clicks it. It is a faithful representation of the underlying Minecraft lever block property. However, the actual semantics of this field are a bit context-sensitive. In the Zombie invasion mission, when a lever is powered, it points down (negative Y direction), but in the USAR singleplayer mission, when a lever is powered, it points up (positive Z direction). Even more confusingly, when the lever becomes powered in the Zombie mission, the iron door opens, however in the USAR Singleplayer mission, the lights in the hallway turn on when the lever is _unpowered_. So this is just something to keep in mind, and perhaps we want to separate out the event handlers a bit - rather than having most of them in `ForgeEventHandlers`, we may want to move some of the mission-specific event handling logic into the respective mission classes.

```json
{
    "was_powered": true,
    "player_name": "tomcat",
    "block_position": {
        "x": -2151.0,
        "y": 53.0,
        "z": 177.0
    },
    "block_type": "net.minecraft.block.BlockLever",
    "block_material": "minecraft:lever",
    "event_type": "edu.arizona.tomcat.Events.LeverFlip",
    "timestamp": "2020-04-26T23:11:31:213Z"
}
```

### Block break

The block break event was added to capture when victims are triaged in the USAR Singleplayer mission. Here is an example.

```json
{
    "player_name": "tomcat",
    "block_position": {
        "x": -2148.0,
        "y": 52.0,
        "z": 180.0
    },
    "block_type": "net.minecraft.block.Block",
    "block_material": "minecraft:gold_block",
    "event_type": "edu.arizona.tomcat.Events.BlockBreakEvent",
    "timestamp": "2020-04-26T23:12:00:510Z"
}
```

The type of victim is given by the block type and material (gold for severely injured victims, prismarine for less-severely injured victims).

Data that we may want to explicitly capture in the future include:
- type of click (left or right)
- item that was used to break the block
- start and stop times for durations when the player is breaking a block.