### PR TITLE
Fixing issue with duplicate RightClickBlock events, moving event handler registration outside MalmoMod.java

### DIFF
--- a/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
+++ b/external/malmo/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
@@ -41,7 +41,6 @@ import com.microsoft.Malmo.Utils.ScoreHelper;
 import com.microsoft.Malmo.Utils.ScreenHelper;
 import com.microsoft.Malmo.Utils.TCPUtils;
 import edu.arizona.tomcat.ASISTBlocks.ModBlocks;
-import edu.arizona.tomcat.Events.ForgeEventHandler;
 import edu.arizona.tomcat.Messaging.TomcatMessaging.TomcatMessage;
 import edu.arizona.tomcat.Messaging.TomcatMessaging.TomcatMessageHandler;
 import io.netty.buffer.ByteBuf;
@@ -115,11 +114,6 @@ public class MalmoMod {
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-
-        MinecraftForge.EVENT_BUS.register(
-            new ForgeEventHandler()); // Registering this here so it's
-                                      // accessible outside missions.
-
         ModBlocks.init();
         ModBlocks.register(); // Tells Minecraft about our blocks when it's
                               // loading up

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
@@ -12,6 +12,7 @@ public class BlockInteraction extends Event {
     private Position blockPosition;
     private String blockType;
     private String blockMaterial;
+    private String clickType;
 
     protected IBlockState getBlockState(PlayerInteractEvent event) {
         return event.getWorld().getBlockState(event.getPos());
@@ -21,8 +22,6 @@ public class BlockInteraction extends Event {
         return this.getBlockState(event).getBlock();
     }
 
-
-
     /** A constructor for general block interaction events. */
     public BlockInteraction(PlayerInteractEvent event) {
         this.playerName = event.getEntityPlayer().getDisplayNameString();
@@ -30,5 +29,6 @@ public class BlockInteraction extends Event {
         this.blockPosition = new Position(pos);
         this.blockType = this.getBlock(event).getClass().getName();
         this.blockMaterial = this.getBlock(event).getRegistryName().toString();
+        this.clickType = (event instanceof PlayerInteractEvent.RightClickBlock)?"right":"left";
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
@@ -16,6 +16,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import net.minecraft.util.EnumHand;
 
 public class ForgeEventHandler {
 
@@ -75,7 +76,7 @@ public class ForgeEventHandler {
      */
     @SubscribeEvent
     public void handle(PlayerInteractEvent.RightClickBlock event) {
-        if (!event.getWorld().isRemote) {
+        if (event.getSide() == Side.CLIENT && event.getHand() == EnumHand.MAIN_HAND) {
             Block block = this.getBlock(event);
             if (block instanceof BlockLever) {
                 this.mqttService.publish(new LeverFlip(event),
@@ -99,7 +100,7 @@ public class ForgeEventHandler {
      */
     @SubscribeEvent
     public void handle(PlayerInteractEvent.LeftClickBlock event) {
-        if (!event.getWorld().isRemote) {
+        if (event.getSide() == Side.CLIENT && event.getHand() == EnumHand.MAIN_HAND) {
             this.mqttService.publish(new BlockInteraction(event),
                                      "observations/events/player_interactions/left_clicks/blocks");
         }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/ForgeEventHandler.java
@@ -12,6 +12,7 @@ import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -22,6 +23,17 @@ public class ForgeEventHandler {
 
     private Block getBlock(PlayerInteractEvent.RightClickBlock event) {
         return event.getWorld().getBlockState(event.getPos()).getBlock();
+    }
+
+    private static ForgeEventHandler instance = null;
+    private ForgeEventHandler() {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    public static ForgeEventHandler getInstance() {
+        if (instance == null) {
+            instance = new ForgeEventHandler();
+        }
+        return instance;
     }
 
     /** Instance of the MqttService singleton to use for publishing messages. */

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Mission.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Mission.java
@@ -4,6 +4,7 @@ import com.microsoft.Malmo.MalmoMod;
 import com.microsoft.Malmo.Schemas.PosAndDirection;
 import edu.arizona.tomcat.Emotion.EmotionHandler;
 import edu.arizona.tomcat.Events.EntityDeath;
+import edu.arizona.tomcat.Events.ForgeEventHandler;
 import edu.arizona.tomcat.Messaging.MqttService;
 import edu.arizona.tomcat.Messaging.TomcatClientServerHandler;
 import edu.arizona.tomcat.Messaging.TomcatMessageData;
@@ -63,6 +64,7 @@ public abstract class Mission implements FeedbackListener, PhaseListener {
     protected ArrayList<MissionListener> listeners;
     protected HashMap<Entity, Long> entitiesToRemove;
     protected MissionInitializer initializer;
+    private ForgeEventHandler forgeEventHandler = ForgeEventHandler.getInstance();
 
     /**
      * Abstract constructor for initialization of the drawing handler


### PR DESCRIPTION
This PR fixes an issue where duplicate events were being fired when players right-clicked blocks that were not meant to be interacted with via right clicks (i.e. unlike doors, levers, etc). An event would be fired for both the 'main' hand and the 'off' hand - we now restrict the event to fire only for the 'main' hand.

The ForgeEventHandler class is now being registered outside `MalmoMod.java` inside its constructor - it has been turned into a singleton class.

Additionally, `BlockInteraction` events now specify whether the interaction was a left or right click.