### PR TITLE
Added EntityInteraction events, data about item held in events

### DIFF
--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockBreakEvent.java
@@ -1,16 +1,17 @@
 package edu.arizona.tomcat.Events;
 
 import edu.arizona.tomcat.World.Position;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.block.state.IBlockState;
-import net.minecraftforge.event.world.BlockEvent;
 import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.event.world.BlockEvent;
 
 public class BlockBreakEvent extends Event {
     private String playerName;
     private Position blockPosition;
     private String blockType;
     private String blockMaterial;
+    private String itemHeld;
 
     /** A constructor for general block breaking events. */
     public BlockBreakEvent(BlockEvent.BreakEvent event) {
@@ -18,6 +19,9 @@ public class BlockBreakEvent extends Event {
         BlockPos pos = event.getPos();
         this.blockPosition = new Position(pos);
         this.blockType = event.getState().getBlock().getClass().getName();
-        this.blockMaterial = event.getState().getBlock().getRegistryName().toString();
+        this.blockMaterial =
+            event.getState().getBlock().getRegistryName().toString();
+        this.itemHeld =
+            event.getPlayer().getHeldItemMainhand().getDisplayName();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/BlockInteraction.java
@@ -1,11 +1,11 @@
 package edu.arizona.tomcat.Events;
 
 import edu.arizona.tomcat.World.Position;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.block.state.IBlockState;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import net.minecraft.block.material.MapColor;
 import net.minecraft.block.Block;
+import net.minecraft.block.material.MapColor;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 public class BlockInteraction extends Event {
     private String playerName;
@@ -13,6 +13,7 @@ public class BlockInteraction extends Event {
     private String blockType;
     private String blockMaterial;
     private String clickType;
+    private String itemHeld;
 
     protected IBlockState getBlockState(PlayerInteractEvent event) {
         return event.getWorld().getBlockState(event.getPos());
@@ -29,6 +30,9 @@ public class BlockInteraction extends Event {
         this.blockPosition = new Position(pos);
         this.blockType = this.getBlock(event).getClass().getName();
         this.blockMaterial = this.getBlock(event).getRegistryName().toString();
-        this.clickType = (event instanceof PlayerInteractEvent.RightClickBlock)?"right":"left";
+        this.clickType = (event instanceof PlayerInteractEvent.RightClickBlock)
+                             ? "right"
+                             : "left";
+        this.itemHeld = event.getItemStack().getDisplayName();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/DoorInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/DoorInteraction.java
@@ -1,14 +1,16 @@
 package edu.arizona.tomcat.Events;
 
-import net.minecraft.block.properties.PropertyBool;
-import net.minecraft.block.BlockDoor;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDoor;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 public class DoorInteraction extends BlockInteraction {
 
-    /** Returns true if the door was originally open (prior to the player
-     * right-clicking it), and false otherwise. */
+    /**
+     * Returns true if the door was originally open (prior to the player
+     * right-clicking it), and false otherwise.
+     */
     private Boolean wasOpen;
 
     /** A constructor for door opening/closing events. */

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/EntityInteraction.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/EntityInteraction.java
@@ -1,0 +1,36 @@
+package edu.arizona.tomcat.Events;
+
+import edu.arizona.tomcat.World.Position;
+import edu.arizona.tomcat.World.Velocity;
+import java.util.UUID;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+public class EntityInteraction extends Event {
+    private String playerName;
+    private String targetType;
+
+    /** The unique ID of the target entity. */
+    private UUID targetId;
+
+    private Position targetPosition;
+    private Velocity targetVelocity;
+
+    /** The item that the player was holding at the time of the interaction. */
+    private String itemHeld;
+
+    /**
+     * A constructor for general entity interaction events (when a player
+     * right-clicks an entity).
+     */
+    public EntityInteraction(PlayerInteractEvent.EntityInteract event) {
+        this.playerName = event.getEntityPlayer().getDisplayNameString();
+        Entity target = event.getTarget();
+        this.targetType = target.getClass().getName();
+        this.targetId = target.getUniqueID();
+        this.targetPosition = new Position(target);
+        this.targetVelocity = new Velocity(target);
+        this.itemHeld = event.getItemStack().getDisplayName();
+    }
+}

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/Event.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/Event.java
@@ -2,7 +2,7 @@ package edu.arizona.tomcat.Events;
 import edu.arizona.tomcat.Utils.TimeStamper;
 
 public class Event {
-    private String eventType; 
+    private String eventType;
     private String timestamp;
     public Event() {
         this.eventType = this.getClass().getName();

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/LeverFlip.java
@@ -1,19 +1,22 @@
 package edu.arizona.tomcat.Events;
 
-import net.minecraft.block.properties.PropertyBool;
-import net.minecraft.block.BlockLever;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLever;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 public class LeverFlip extends BlockInteraction {
 
-    /** Returns true if the lever was originally powered (prior to the player
-     * right-clicking it), and false otherwise. */
+    /**
+     * Returns true if the lever was originally powered (prior to the player
+     * right-clicking it), and false otherwise.
+     */
     private Boolean wasPowered;
 
     /** A constructor for lever flipping events. */
     public LeverFlip(PlayerInteractEvent.RightClickBlock event) {
         super(event);
-        this.wasPowered = this.getBlockState(event).getValue(BlockLever.POWERED);
+        this.wasPowered =
+            this.getBlockState(event).getValue(BlockLever.POWERED);
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/MobAttacked.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Events/MobAttacked.java
@@ -19,6 +19,7 @@ public class MobAttacked extends Event {
     private String targetType;
     /** The unique ID of the target mob. */
     private UUID targetId;
+    private String itemHeld;
 
     /** The health of the target *before* the event. */
     private double targetHealth;
@@ -32,5 +33,7 @@ public class MobAttacked extends Event {
         this.targetHealth = target.getHealth();
         this.targetPosition = new Position(target);
         this.targetVelocity = new Velocity(target);
+        this.itemHeld =
+            player.getHeldItemMainhand().getDisplayName();
     }
 }

--- a/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Mission.java
+++ b/external/malmo/Minecraft/src/main/java/edu/arizona/tomcat/Mission/Mission.java
@@ -64,7 +64,8 @@ public abstract class Mission implements FeedbackListener, PhaseListener {
     protected ArrayList<MissionListener> listeners;
     protected HashMap<Entity, Long> entitiesToRemove;
     protected MissionInitializer initializer;
-    private ForgeEventHandler forgeEventHandler = ForgeEventHandler.getInstance();
+    private ForgeEventHandler forgeEventHandler =
+        ForgeEventHandler.getInstance();
 
     /**
      * Abstract constructor for initialization of the drawing handler


### PR DESCRIPTION
Adding EntityInteraction events, information about item held for block and entity interactions
===================================================================

This PR implements a new event type: EntityInteraction: when a player interacts with an entity, but the interaction is not an attack - e.g. putting the lead on the search-and-rescue assistant dog in the USAR Singleplayer mission. It also adds data about what item the player was holding for `BlockInteraction`,  `BlockBreak`, and `MobAttack` events, and autoformatting.

Examples
----------

### EntityInteraction

```json
{
    "player_name": "tomcat",
    "target_type": "net.minecraft.entity.passive.EntityWolf",
    "target_id": "cc463636-3d6e-453f-8810-bffeb2df1a80",
    "target_position": {
        "x": -2160.50634765625,
        "y": 52.0,
        "z": 179.57275390625
    },
    "target_velocity": {
        "x": 0.0,
        "y": -0.029718657514397936,
        "z": 0.0
    },
    "item_held": "Lead",
    "event_type": "edu.arizona.tomcat.Events.EntityInteraction",
    "timestamp": "2020-04-28T02:48:15:650Z"
}
```

### BlockInteraction:

```json
{
    "player_name": "tomcat",
    "block_position": {
        "x": -2148.0,
        "y": 52.0,
        "z": 160.0
    },
    "block_type": "net.minecraft.block.BlockPrismarine",
    "block_material": "minecraft:prismarine",
    "click_type": "left",
    "item_held": "First Aid Kit",
    "event_type": "edu.arizona.tomcat.Events.BlockInteraction",
    "timestamp": "2020-04-28T02:52:54:712Z"
}
```

### BlockBreak:

```json
{
    "player_name": "tomcat",
    "block_position": {
        "x": -2148.0,
        "y": 52.0,
        "z": 160.0
    },
    "block_type": "net.minecraft.block.BlockPrismarine",
    "block_material": "minecraft:prismarine",
    "item_held": "First Aid Kit",
    "event_type": "edu.arizona.tomcat.Events.BlockBreakEvent",
    "timestamp": "2020-04-28T02:53:02:283Z"
}
```