### PR TITLE
Adding PLAYER_ID variable

### DIFF
--- a/tools/configuration_helpers
+++ b/tools/configuration_helpers
@@ -61,6 +61,11 @@ set_local_configuration() {
     # DEFAULT_MAIN_MISSION_TIME: Allows for short missions for testing. 
     export DEFAULT_MAIN_MISSION_TIME=${DEFAULT_MAIN_MISSION_TIME:-600} 
 
+    # PLAYER_ID - the id of the player who is running the mission. Defaults to
+    # the value stored in the USER environment variable.
+    export PLAYER_ID=${PLAYER_ID:-$USER}
+
+
     export TOMCAT_TMP_DIR="/tmp/$USER/tomcat"
     mkdir -p "${TOMCAT_TMP_DIR}"
 

--- a/tools/generate_session_metadata
+++ b/tools/generate_session_metadata
@@ -17,7 +17,7 @@ timestamp = datetime.now().isoformat()
 metadata = {
     "session_id": sys.argv[1],  # Get UUID from command line argument
     "timestamp": timestamp+"Z",
-    "player_id": os.getenv("USER"),
+    "player_id": sys.argv[2]
 }
 
 print(json.dumps(metadata, indent=4))  # Serialize metadata

--- a/tools/run_session
+++ b/tools/run_session
@@ -30,7 +30,7 @@ session_output_dir="${TOMCAT}"/data/participant_data/"$session_uuid"
 mkdir -p "${session_output_dir}"
 
 # Generate metadata file for the session
-"$TOMCAT"/tools/generate_session_metadata "$session_uuid" > "$session_output_dir"/metadata.json
+"$TOMCAT"/tools/generate_session_metadata "$session_uuid" "$PLAYER_ID" > "$session_output_dir"/metadata.json
 if [[ $? -ne 0 ]]; then exit 1; fi
 
 


### PR DESCRIPTION
This PR adds a PLAYER_ID variable that can be set during internal data collection if a team member is having a friend/family member play the mission on their laptop.

Example usage:

    PLAYER_ID="Wilbur Wildcat" MAIN_MISSION=2 ./tools/run_session