### PR TITLE
Fix for Ubuntu adding .gz suffix to .tgz files downloaded from Google Drive

### DIFF
--- a/tools/extract_TA3_world
+++ b/tools/extract_TA3_world
@@ -8,5 +8,11 @@ TOMCAT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" >/dev/null 2>&1 && pwd)"
 export TOMCAT
 
 pushd "$TOMCAT"/data/worlds > /dev/null
+    if [[ -f Singleplayer.tgz.gz ]]; then
+        echo "Found a file named Singleplayer.tgz.gz. "\
+             "Ubuntu appends .gz to .tgz files downloaded from Google Drive. "\
+             "We will now rename it to Singleplayer.tgz"
+        mv Singleplayer.tgz.gz Singleplayer.tgz
+    fi
     tar -xzf Singleplayer.tgz
 popd > /dev/null


### PR DESCRIPTION
This PR implements a fix in `extract_TA3_world` for the situation where Ubuntu appends the `.gz` suffix to `.tgz` files downloaded from Google Drive. 