### PR TITLE
TA3 message file replayer

### DIFF
--- a/tools/elkless_replayer
+++ b/tools/elkless_replayer
@@ -3,8 +3,9 @@
 # ELKless Replayer is a simple program to replay messages from a file
 # containing messages collected during a TA3 experimental trial and dumped from
 # an Elasticsearch database.
-
 # The script relies on the availability of the mosquitto_pub client executable.
+# To see the command line arguments and invocation pattern, run
+#     ./elkless_replayer -h
 
 import sys
 import json
@@ -13,10 +14,14 @@ import subprocess as sp
 
 if __name__ == "__main__":
     try:
-        sp.run(["command", "-v", "mosquitto_pub"], check=True, capture_output=True)
+        sp.run(
+            ["command", "-v", "mosquitto_pub"], check=True, capture_output=True
+        )
     except sp.CalledProcessError as e:
-        sys.exit("Could not find the mosquitto_pub client executable - "
-                "please make sure it is installed.")
+        sys.exit(
+            "Could not find the mosquitto_pub client executable - "
+            "please make sure it is installed."
+        )
 
     parser = argparse.ArgumentParser(description="ELKless Replayer")
     parser.add_argument("input", help="The messages file to replay to the bus")
@@ -28,7 +33,6 @@ if __name__ == "__main__":
         default=1883,
     )
     args = parser.parse_args()
-    timestamp = ""
     with open(args.input, "r") as f:
         for line in f:
             data = json.loads(line)
@@ -55,5 +59,6 @@ if __name__ == "__main__":
                     + str(e.returncode)
                     + ".\n"
                     + "Please check if the mosquitto broker is up and running on port "
-                    + str(args.port)+"."
+                    + str(args.port)
+                    + "."
                 )

--- a/tools/elkless_replayer
+++ b/tools/elkless_replayer
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# A simple Python script to replay messages from a TA3 experiment to the message bus.
+import sys
+import json
+import argparse
+import subprocess as sp
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="The messages file to replay to the bus")
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        help="Port that the mosquitto message broker is running on.",
+        default=1883,
+    )
+    args = parser.parse_args()
+    timestamp = ""
+    with open(args.input, "r") as f:
+        for line in f:
+            data = json.loads(line)
+            new_timestamp = data["@timestamp"]
+            print(new_timestamp, timestamp)
+            if new_timestamp < timestamp:
+                print("causality violated!")
+            timestamp = new_timestamp
+            for key in ("message", "@timestamp", "@version", "host"):
+                del data[key]
+            topic = data.pop("topic")
+            try:
+                sp.run(
+                    [
+                        "mosquitto_pub",
+                        "-p",
+                        str(args.port),
+                        "-t",
+                        topic,
+                        "-m",
+                        json.dumps(data),
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+            except sp.CalledProcessError as e:
+                print(
+                    "Call to mosquitto_pub exited with return code "
+                    + str(e.returncode)
+                    + ".",
+                    "Please check if the mosquitto broker is up and running on port",
+                    str(args.port),
+                )
+                break

--- a/tools/elkless_replayer
+++ b/tools/elkless_replayer
@@ -1,13 +1,24 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-# A simple Python script to replay messages from a TA3 experiment to the message bus.
+# ELKless Replayer is a simple program to replay messages from a file
+# containing messages collected during a TA3 experimental trial and dumped from
+# an Elasticsearch database.
+
+# The script relies on the availability of the mosquitto_pub client executable.
+
 import sys
 import json
 import argparse
 import subprocess as sp
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    try:
+        sp.run(["command", "-v", "mosquitto_pub"], check=True, capture_output=True)
+    except sp.CalledProcessError as e:
+        sys.exit("Could not find the mosquitto_pub client executable - "
+                "please make sure it is installed.")
+
+    parser = argparse.ArgumentParser(description="ELKless Replayer")
     parser.add_argument("input", help="The messages file to replay to the bus")
     parser.add_argument(
         "-p",
@@ -21,11 +32,6 @@ if __name__ == "__main__":
     with open(args.input, "r") as f:
         for line in f:
             data = json.loads(line)
-            new_timestamp = data["@timestamp"]
-            print(new_timestamp, timestamp)
-            if new_timestamp < timestamp:
-                print("causality violated!")
-            timestamp = new_timestamp
             for key in ("message", "@timestamp", "@version", "host"):
                 del data[key]
             topic = data.pop("topic")
@@ -44,11 +50,10 @@ if __name__ == "__main__":
                     capture_output=True,
                 )
             except sp.CalledProcessError as e:
-                print(
+                sys.exit(
                     "Call to mosquitto_pub exited with return code "
                     + str(e.returncode)
-                    + ".",
-                    "Please check if the mosquitto broker is up and running on port",
-                    str(args.port),
+                    + ".\n"
+                    + "Please check if the mosquitto broker is up and running on port "
+                    + str(args.port)+"."
                 )
-                break

--- a/tools/elkless_replayer
+++ b/tools/elkless_replayer
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 
-# ELKless Replayer is a simple program to replay messages from a file
-# containing messages collected during a TA3 experimental trial and dumped from
-# an Elasticsearch database.
-# The script relies on the availability of the mosquitto_pub client executable.
+""" ELKless Replayer is a simple program to replay messages from a file
+containing messages collected during a TA3 experimental trial and dumped from
+an Elasticsearch database.
+
+For each line in the input file, it extracts the JSON-serialized message and
+the topic it was published to, and republishes the message to the same
+topic."""
+
 # To see the command line arguments and invocation pattern, run
 #     ./elkless_replayer -h
 
@@ -23,7 +27,8 @@ if __name__ == "__main__":
             "please make sure it is installed."
         )
 
-    parser = argparse.ArgumentParser(description="ELKless Replayer")
+    # Argument parsing
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("input", help="The messages file to replay to the bus")
     parser.add_argument(
         "-p",
@@ -33,12 +38,20 @@ if __name__ == "__main__":
         default=1883,
     )
     args = parser.parse_args()
+
+    # Open the input file, parse each line in it as a JSON-serialized object.
     with open(args.input, "r") as f:
         for line in f:
             data = json.loads(line)
+            # Delete keys that were not in the original message, for more
+            # faithful replaying.
             for key in ("message", "@timestamp", "@version", "host"):
                 del data[key]
+
+            # Get the topic to publish the message to.
             topic = data.pop("topic")
+
+            # Publish the message to the given topic.
             try:
                 sp.run(
                     [


### PR DESCRIPTION
This PR adds a script to replay messages from a file created from an Elasticsearch dump of messages collected during an ASIST TA3 experimental trial. The script relies on the `mosquitto_pub` client executable, and does not require the ELK stack.