### PR TITLE
Fix for corner cases in elkless_replayer

### DIFF
--- a/tools/elkless_replayer
+++ b/tools/elkless_replayer
@@ -8,11 +8,13 @@ For each line in the input file, it extracts the JSON-serialized message and
 the topic it was published to, and republishes the message to the same
 topic."""
 
+# Requires the python-dateutil package.
 # To see the command line arguments and invocation pattern, run
 #     ./elkless_replayer -h
 
 import sys
 import json
+from dateutil.parser import parse
 import argparse
 import subprocess as sp
 
@@ -42,7 +44,9 @@ if __name__ == "__main__":
     # Open the input file, parse each line in it as a JSON-serialized object.
     with open(args.input, "r") as f:
         messages = [json.loads(line) for line in f]
-        for data in sorted(messages, key = lambda x: x["@timestamp"]):
+        for data in sorted(
+            messages, key=lambda x: parse(x["@timestamp"])
+        ):
             # Delete keys that were not in the original message, for more
             # faithful replaying.
             for key in ("message", "@timestamp", "@version", "host"):


### PR DESCRIPTION
This PR implements a fix for a few corner cases where the elkless_replayer script did not sort the messages correctly by time. The issue was that the timestamps were being treated as strings, and the string comparison function did not work perfectly for comparing timestamps in this representation.

This update uses the `python-dateutil` package to parse the ISO-8601 timestamps properly and enable correct comparison. Thanks to @pmdoll for discovering this issue.