### PR TITLE
Bugfix for tools/install

### DIFF
--- a/tools/install
+++ b/tools/install
@@ -28,22 +28,25 @@ __build_tomcat() {
         mkdir build
 
         pushd build > /dev/null
-            if (( CI )); then
-                if [[ $OSTYPE == "linux-gnu" ]]; then
-                    if ! cmake ${TOMCAT} -DBUILD_EXAMPLES=ON; then exit 1; fi
-                else
-                    # On the macOS Github Actions runner, there is a problem
-                    # with building against OpenCV with Homebrew - something to
-                    # do with XCode and the Command Line Tools not playing
-                    # nicely together. The line below is a fix for this issue.
-                    sudo xcode-select -s /Library/Developer/CommandLineTools
-                fi
+            if [[ $CI -eq 1 && $OSTYPE == "darwin"* ]]; then
+                # On the macOS Github Actions runner, there is a problem
+                # with building against OpenCV with Homebrew - something to
+                # do with XCode and the Command Line Tools not playing
+                # nicely together. The line below is a fix for this issue.
+                sudo xcode-select -s /Library/Developer/CommandLineTools
             fi
 
             if [[ $OSTYPE == "linux-gnu" ]]; then
                 NJOBS=$(nproc)
             else
                 NJOBS=$(sysctl -n hw.ncpu)
+            fi
+
+
+            # On CI, we build the examples by default.
+            if (( CI )); then
+                if ! cmake ${TOMCAT} -DBUILD_EXAMPLES=ON; then exit 1; fi
+            else
                 if ! cmake ${TOMCAT}; then exit 1; fi
             fi
 #           Needed to build in docker!

--- a/tools/install
+++ b/tools/install
@@ -49,8 +49,7 @@ __build_tomcat() {
             else
                 if ! cmake ${TOMCAT}; then exit 1; fi
             fi
-#           Needed to build in docker!
-            cmake ${TOMCAT} -DBUILD_EXAMPLES=ON
+
             if ! make -j $NJOBS; then exit 1; fi
             if ! make -j $NJOBS Minecraft; then exit 1; fi
         popd > /dev/null


### PR DESCRIPTION
As @pmdoll pointed out in #193 , the `tools/install` script implicitly assumed that the environment variable `CI` would be equal to 1. This PR fixes that issue.