### PR TITLE
Adding install targets for mcg

### DIFF
--- a/libs/mcg/CMakeLists.txt
+++ b/libs/mcg/CMakeLists.txt
@@ -26,3 +26,6 @@ option(BUILD_EXAMPLES "Enable building of the example programs" OFF)
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
+
+install(TARGETS mcg DESTINATION lib) 
+install(FILES ${mcg_headers} DESTINATION include/mcg) 

--- a/tools/install_dependencies
+++ b/tools/install_dependencies
@@ -75,7 +75,7 @@ __install_dependencies_using_homebrew() {
 
     # We enable system audio recording ononly on macOS Catalina or above
     if (( ENABLE_SYSTEM_AUDIO_RECORDING )); then
-        brew cask install blackhole
+        brew install --cask blackhole
         if [[ $? -ne 0 && $? -ne 1 ]]; then exit 1; fi
 
         brew install switchaudio-osx


### PR DESCRIPTION
This PR adds CMake install targets for `mcg` so it can be installed as a system-wide library if desired.