### PR TITLE
Big sur update

### DIFF
--- a/tools/configuration_helpers
+++ b/tools/configuration_helpers
@@ -100,6 +100,7 @@ set_local_configuration() {
 detect_os() {
     if [[ "$OSTYPE" == "darwin"* ]]; then
         echo "macOS detected."
+        export MACOS_MAJOR_VERSION=$(sw_vers -productVersion | cut -d '.' -f1)
         export MACOS_MINOR_VERSION=$(sw_vers -productVersion | cut -d '.' -f2)
 
         # We set the path to MacPorts so that users don't necessarily need to
@@ -114,7 +115,7 @@ detect_os() {
             export PATH="$PATH:/opt/local/bin:/opt/local/sbin"
         fi
 
-        if (( MACOS_MINOR_VERSION < 15 )); then
+        if (( MACOS_MAJOR_VERSION == 10 && MACOS_MINOR_VERSION < 15 )); then
             echo "macOS version older than 10.15 (Catalina). "\
                 "System audio recording will be disabled."
             export ENABLE_SYSTEM_AUDIO_RECORDING=0

--- a/tools/install_dependencies
+++ b/tools/install_dependencies
@@ -153,7 +153,7 @@ __install_dependencies() {
             __install_dependencies_using_macports
 
         elif [[ $MACPORTS_FOUND -eq 0 && $HOMEBREW_FOUND -eq 1 ]]; then
-            echo "Both Homebrew and MacPorts package managers have been found."
+            echo "MacPorts found."
             echo "Proceeding to install dependencies using MacPorts."
             __install_dependencies_using_macports
 

--- a/tools/install_from_source/macports
+++ b/tools/install_from_source/macports
@@ -1,15 +1,24 @@
 #!/bin/bash
 
+# Script to install MacPorts from source.
+set -euo pipefail
+
 install_macports() {
-  local version=2.6.2
+
+  # Version 2.7.0 is the latest as of May 21, 2021.
+  local version=2.7.0
+
   curl -O https://distfiles.macports.org/MacPorts/MacPorts-$version.tar.bz2
-  if [[ $? -ne 0 ]]; then exit 1; fi
-  if ! tar xf MacPorts-$version.tar.bz2; then exit 1; fi
+
+  tar xf MacPorts-$version.tar.bz2
+
   pushd MacPorts-$version > /dev/null
-    if ! ./configure; then exit 1; fi
-    if ! make -j; then exit 1; fi
-    if ! sudo make -j install; then exit 1; fi
+    ./configure
+    make -j
+    make -j install
   popd > /dev/null
+
+  # Remove the .tar.bz2 file
   /bin/rm -rf Macports-$version*
 }
 

--- a/tools/install_from_source/macports
+++ b/tools/install_from_source/macports
@@ -15,7 +15,7 @@ install_macports() {
   pushd MacPorts-$version > /dev/null
     ./configure
     make -j
-    make -j install
+    sudo make -j install
   popd > /dev/null
 
   # Remove the .tar.bz2 file


### PR DESCRIPTION
This PR updates the installation scripts to be compatible with macOS Big Sur, and also fixes a user-facing message that is emitted when MacPorts is present on a system and Homebrew is not.