### PR TITLE
Update Mumble helper script

### DIFF
--- a/tools/mumble_helper
+++ b/tools/mumble_helper
@@ -32,6 +32,7 @@ while getopts ":h" opt; do
 done
 
 SUBCOMMAND=$1
+VERSION="1.3.3"
 
 case "$SUBCOMMAND" in
     install)
@@ -41,25 +42,25 @@ case "$SUBCOMMAND" in
         fi
 
         if [[ ! -f Mumble-1.3.2.dmg ]]; then
-            echo "Downloading Mumble-1.3.2.dmg..."
+            echo "Downloading Mumble-${VERSION}.dmg..."
             curl -LO https://dl.mumble.info/stable/Mumble-1.3.2.dmg
         fi
 
-        if [[ -f Mumble-1.3.2.dmg ]]; then
+        if [[ -f Mumble-${VERSION}.dmg ]]; then
             echo "Mounting the Mumble disk image..."
             hdiutil attach Mumble-1.3.2.dmg
         fi
 
-        if [[ -d "/Volumes/Mumble 1.3.2" ]]; then
+        if [[ -d "/Volumes/Mumble ${VERSION}" ]]; then
             echo "Copying Mumble.app to /Applications..."
             cp -R "/Volumes/Mumble 1.3.2/Mumble.app" /Applications
 
             echo "Unmounting the Mumble disk image..."
-            hdiutil unmount "/Volumes/Mumble 1.3.2"
+            hdiutil unmount "/Volumes/Mumble ${VERSION}"
         fi
 
-        echo "Finished installing Mumble. Removing Mumble-1.3.2.dmg..."
-        /bin/rm Mumble-1.3.2.dmg
+        echo "Finished installing Mumble. Removing Mumble-${VERSION}.dmg..."
+        /bin/rm Mumble-${VERSION}.dmg
 
         echo "Mumble installation complete!"
         ;;

--- a/tools/mumble_helper
+++ b/tools/mumble_helper
@@ -41,19 +41,19 @@ case "$SUBCOMMAND" in
                  "like Mumble is already installed."
         fi
 
-        if [[ ! -f Mumble-1.3.2.dmg ]]; then
+        if [[ ! -f Mumble-${VERSION}.dmg ]]; then
             echo "Downloading Mumble-${VERSION}.dmg..."
-            curl -LO https://dl.mumble.info/stable/Mumble-1.3.2.dmg
+            curl -LO https://dl.mumble.info/stable/Mumble-${VERSION}.dmg
         fi
 
         if [[ -f Mumble-${VERSION}.dmg ]]; then
             echo "Mounting the Mumble disk image..."
-            hdiutil attach Mumble-1.3.2.dmg
+            hdiutil attach Mumble-${VERSION}.dmg
         fi
 
         if [[ -d "/Volumes/Mumble ${VERSION}" ]]; then
             echo "Copying Mumble.app to /Applications..."
-            cp -R "/Volumes/Mumble 1.3.2/Mumble.app" /Applications
+            cp -R "/Volumes/Mumble ${VERSION}/Mumble.app" /Applications
 
             echo "Unmounting the Mumble disk image..."
             hdiutil unmount "/Volumes/Mumble ${VERSION}"

--- a/tools/setup_murmur
+++ b/tools/setup_murmur
@@ -5,12 +5,16 @@
 
 set -euo pipefail
 
-if [[ ! -d murmur-static_x86-1.3.2 ]]; then
-    curl -LO https://www.mumble.info/downloads/linux-static-server
+VERSION=1.3.4
+MURMUR_DOWNLOAD_URL=https://dl.mumble.info/latest/stable/server-linux-x86
+
+if [[ ! -d murmur-static_x86-${VERSION} ]]; then
+    echo "Downloading murmur..."
+    curl -LO ${MURMUR_DOWNLOAD_URL} 
     tar -xvjf linux-static-server
 fi
 
-pushd murmur-static_x86-1.3.2
+pushd murmur-static_x86-${VERSION}
     sudo mkdir -p /usr/local/murmur
     sudo cp -r * /usr/local/murmur/
     sudo cp murmur.ini /etc/murmur.ini


### PR DESCRIPTION
This PR updates the mumble_helper script to make the version more easily changeable, and updated the Mumble version in the script from 1.3.2 to 1.3.3.

The `setup_murmur` script has also been updated to make the version and download URL more easily exposed for configuration.