### PR TITLE
final commit

### DIFF
--- a/human_experiments/scripts/inventory_script/inventory_script.py
+++ b/human_experiments/scripts/inventory_script/inventory_script.py
@@ -1,51 +1,125 @@
-from itertools import count
-import sys  # We use sys.exit() so that all exceptions can properly propogate up and cause the interpreter to exit.
+import sys  # Use sys.exit() so that all exceptions can properly propogate up and cause the interpreter to exit.
 import os
-import json
 import argparse
-import datetime
 from termcolor import colored
+from utils import (
+    checkfile_minecraft,
+    fcount_baseline_task,
+    check_audio,
+    check_vocalics,
+    check_xdf,
+    check_pupil_recorder,
+    check_asist_folder,
+    inventory_script_logging,
+)
 
-from utils import checkfile_minecraft, fcount_baseline_task, \
-                  check_audio, check_vocalics, check_xdf, \
-                  check_pupil_recorder, check_asist_folder
+def inventory_script(rootdir, path_out):
+    if path_out == None:
+        logging_path = os.path.join(rootdir, "sanity_check")
+        logging_path_flag = os.path.exists(logging_path)
+    else:
+        try:
+            logging_path = (
+                path_out + "/sanity_check/" + "exp_" + rootdir.split("exp_", 1)[1]
+            )
+        except:
+            logging_path = (
+                path_out + "/sanity_check/" + "exp_" + rootdir.split("exp_", 1)[0]
+            )
 
-def inventory_script(rootdir):
+        logging_path_flag = os.path.exists(logging_path)
+
+    if not logging_path_flag:
+        os.makedirs(logging_path)
+
+    print(logging_path_flag)
+
+    logger = inventory_script_logging(os.path.join(logging_path, "missing_data.log"))
+    logger.debug("Data_type-Issue-file_path")
+
     dir = os.listdir(rootdir)
-
     if len(dir) == 0:
         # sometime .DS_Store might be there so the length would be 1
         print(
-            colored(
-                "\n[Error] Root directory file is missing", "red", attrs=["bold"]
-            ),
+            colored("\n[Error] Root directory file is missing", "red", attrs=["bold"]),
             "\N{cross mark}",
         )
+        logger.info("\tRoot_directory\Does_not_exist\t{}".format(rootdir))
+
     else:
-        fcount_baseline_task(rootdir+'baseline_tasks')
-        checkfile_minecraft(rootdir+'minecraft')
-        check_xdf(rootdir)
-        check_pupil_recorder(rootdir)
-        check_audio(rootdir, 'lion')
-        check_audio(rootdir, 'tiger')
-        check_audio(rootdir, 'leopard')
-        check_asist_folder(rootdir)
-        check_vocalics(rootdir)
-            
+
+        fcount_baseline_task(rootdir, logger)
+        checkfile_minecraft(rootdir, logger)
+        check_xdf(rootdir, logger, "lion")
+        check_xdf(rootdir, logger, "tiger")
+        check_xdf(rootdir, logger, "leopard")
+        check_pupil_recorder(rootdir, logger, "lion")
+        check_pupil_recorder(rootdir, logger, "tiger")
+        check_pupil_recorder(rootdir, logger, "leopard")
+        check_audio(rootdir, logger, "lion")
+        check_audio(rootdir, logger, "tiger")
+        check_audio(rootdir, logger, "leopard")
+        check_asist_folder(rootdir, logger)
+        check_vocalics(rootdir, logger)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Inventory Script that checks for metadata files from baseline task and minecraft"
     )
+
+    parser.add_argument(
+        "--wrapper",
+        required=False,
+        default=None,
+        help="Wrapper script that runs inventory script over all exp_* folders.",
+    )
+
     parser.add_argument(
         "--p",
         required=True,
-        help="Path to experiment folder",
+        help="Path to single experiment folder. If wrapper script is set to true then add path that contains all exp_* folders. ",
+    )
+
+    parser.add_argument(
+        "--path_out",
+        required=False,
+        default=None,
+        help="Path to external folder to place sanity check logs",
     )
 
     arg = parser.parse_args()
     rootdir = arg.p
-    print(
-        colored("[Status] Root Directory:", "blue", attrs=["bold"]),
-        colored(rootdir, "cyan"),
-    )
-    sys.exit(inventory_script(rootdir))
+    path_out = arg.path_out
+    wrapper = arg.wrapper
+
+    if bool(wrapper) == True:
+        """
+        This section requires wrapper argument to be true and path to subdirectory that has all exp_* folders.
+        """
+        print(
+            colored("[Status] Root Directory:", "blue", attrs=["bold"]),
+            colored(rootdir, "cyan"),
+        )
+
+        for dirs in os.walk(rootdir):
+            # Get a list of all exp_* folder under the path passed as argument
+            dir = dirs[1]
+            break
+
+        for rootdirec in dir:
+            # Run inventory_script over all exp_* folders.
+            print(
+                colored("[Status] Sub Directory:", "blue", attrs=["bold"]),
+                colored(os.path.join(rootdir, rootdirec), "cyan"),
+            )
+            if 'exp_2022_04_01_13' or 'exp_2022_04_22_09' in rootdir:
+                print(
+                    colored("[Status] Skipping Sub Directory:", "yellow", attrs=["bold"]),
+                    colored(os.path.join(rootdir, rootdirec), "cyan"),
+                )
+            else:
+                inventory_script(os.path.join(rootdir, rootdirec), path_out)
+
+    else:
+        sys.exit(inventory_script(rootdir, path_out))

--- a/human_experiments/scripts/inventory_script/utils/__init__.py
+++ b/human_experiments/scripts/inventory_script/utils/__init__.py
@@ -1,4 +1,10 @@
-from .run_minecraft_metadata_validation import checkfile_minecraft, check_audio, check_vocalics, check_asist_folder
+from .run_minecraft_metadata_validation import (
+    checkfile_minecraft,
+    check_audio,
+    check_vocalics,
+    check_asist_folder,
+)
 from .run_baseline_tasks_data_validation import fcount_baseline_task
 from .run_xdf_check import check_xdf
 from .run_pupil_capture_validation import check_pupil_recorder
+from .inventory_script_logger import inventory_script_logging

--- a/human_experiments/scripts/inventory_script/utils/inventory_script_logger.py
+++ b/human_experiments/scripts/inventory_script/utils/inventory_script_logger.py
@@ -1,0 +1,12 @@
+import sys
+import logging
+
+
+def inventory_script_logging(logger_name, level=logging.DEBUG):
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+    console_handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(console_handler)
+    file_handler = logging.FileHandler(logger_name, mode="a")
+    logger.addHandler(file_handler)
+    return logger

--- a/human_experiments/scripts/inventory_script/utils/run_baseline_tasks_data_validation.py
+++ b/human_experiments/scripts/inventory_script/utils/run_baseline_tasks_data_validation.py
@@ -1,77 +1,120 @@
-import csv
-import sys 
+import sys
 import os
-import argparse
 import pandas as pd
 from termcolor import colored
 from time import sleep, ctime
-sys.path.insert(0, '../../lab_software/tomcat-baseline-tasks/')
-from tasks.finger_tapping_task.config import TOTAL_TIME as total_time_finger_tapping 
+
+sys.path.insert(0, "../../lab_software/tomcat-baseline-tasks/")
+from tasks.finger_tapping_task.config import TOTAL_TIME as total_time_finger_tapping
 from tasks.rest_state.config import TOTAL_TIME as total_time_rest_state
 from tasks.affective_task.config import TOTAL_TIME as total_time_affective_task
 from tasks.ping_pong_task.config import TOTAL_TIME as total_time_ping_pong_task
 
-def read_muliple_csv_files(path, csvfiles, total_time):
+
+def read_muliple_csv_files(path, csvfiles, total_time, logging):
     for csvfile in csvfiles:
-        #display which file its currently reading 
-        print(colored('\n\t File:','magenta'), csvfile)
+        # display which file its currently reading
+        print(colored("\n\t File:", "magenta"), csvfile)
 
         try:
-            df = pd.read_csv(os.path.join(path, csvfile), delimiter = ';')
+            df = pd.read_csv(os.path.join(path, csvfile), delimiter=";")
         except:
-            #check if the csv file is empty or not
-            print(colored('[Error] CSV file is empty','red'), u'\N{cross mark}')
+            # check if the csv file is empty or not
+            print(colored("[Error] CSV file is empty", "red"), "\N{cross mark}")
+            logging.info("\tBaseline_task\tcsv_file_empty\t{}".format(path + csvfile))
             break
 
-        #display start and stop the task
-        print(colored('\t Task started at:', 'magenta'), ctime(df['time'].iloc[0]))
-        print(colored('\t Task ended at:', 'magenta'), ctime(df['time'].iloc[-1]))
-        delta = int(float(df['time'].iloc[-1]) - float(df['time'].iloc[0]))
+        # display start and stop the task
+        print(colored("\t Task started at:", "magenta"), ctime(df["time"].iloc[0]))
+        print(colored("\t Task ended at:", "magenta"), ctime(df["time"].iloc[-1]))
+        delta = int(float(df["time"].iloc[-1]) - float(df["time"].iloc[0]))
 
         if delta <= total_time + 3:
-            #check if the time taken by this session is within the range of SECONDS_PER_SESSION in task config file 
-            print(colored('\t Time taken:', 'magenta'), delta, 'Seconds')
+            # check if the time taken by this session is within the range of SECONDS_PER_SESSION in task config file
+            print(colored("\t Time taken:", "magenta"), delta, "Seconds")
         else:
-            print(delta)
-            print(colored('[Error] Timing for task is off by a large margin','red'), u'\N{cross mark}')
+            print(
+                colored("[Error] Timing for task is off by a large margin", "red"),
+                "\N{cross mark}",
+            )
+            logging.info(
+                "\tBaseline_task\tTime_taken_for_task_out_of_range\t{}".format(
+                    path + csvfile
+                )
+            )
 
-def csvread(path, all_files, file_name):
-    #count csv files for ever task
-    csvfiles = list(filter(lambda f: f.endswith('.csv'), all_files))
 
-    if file_name == 'finger_tapping':
+def csvread(path, all_files, file_name, logging):
+    # count csv files for ever task
+    csvfiles = list(filter(lambda f: f.endswith(".csv"), all_files))
+
+    if file_name == "finger_tapping":
         if len(csvfiles) == 1:
-            read_muliple_csv_files(path, csvfiles, total_time_finger_tapping)
+            read_muliple_csv_files(path, csvfiles, total_time_finger_tapping, logging)
         else:
-            print(colored('\n[Error] CSV file under finger tapping task is missing','red'), u'\N{cross mark}')
+            print(
+                colored(
+                    "\n[Error] CSV file under finger tapping task is missing", "red"
+                ),
+                "\N{cross mark}",
+            )
+            logging.info("\tBaseline_task\tFingertapping_csv_does_not_exist")
 
-    elif file_name == 'rest_state':
+    elif file_name == "rest_state":
         if len(csvfiles) == 1:
-            read_muliple_csv_files(path, csvfiles, total_time_rest_state)
+            read_muliple_csv_files(path, csvfiles, total_time_rest_state, logging)
         else:
-            print(colored('\n[Error] CSV file under rest state task is missing','red'), u'\N{cross mark}')
+            print(
+                colored("\n[Error] CSV file under rest state task is missing", "red"),
+                "\N{cross mark}",
+            )
+            logging.info("\tBaseline_task\tRest_state_csv_does_not_exist")
 
-    elif file_name == 'affective':
+    elif file_name == "affective":
         if len(csvfiles) == 4:
-            read_muliple_csv_files(path, csvfiles, total_time_affective_task)
+            read_muliple_csv_files(path, csvfiles, total_time_affective_task, logging)
         else:
-            print(colored('\n[Error] CSV file under affective task is missing','red'), u'\N{cross mark}')
+            print(
+                colored("\n[Error] CSV file under affective task is missing", "red"),
+                "\N{cross mark}",
+            )
+            logging.info("\tBaseline_task\tAffective_task_csv_does_not_exist")
 
-    elif file_name == 'ping_pong':
+    elif file_name == "ping_pong":
         if len(csvfiles) == 3:
-            read_muliple_csv_files(path, csvfiles, total_time_ping_pong_task)
+            read_muliple_csv_files(path, csvfiles, total_time_ping_pong_task, logging)
         else:
-            print(colored('\n[Error] CSV file under ping pong task is missing','red'), u'\N{cross mark}')
+            print(
+                colored("\n[Error] CSV file under ping pong task is missing", "red"),
+                "\N{cross mark}",
+            )
+            logging.info("\tBaseline_task\tPing_pong_task_csv_does_not_exist")
 
-def fcount_baseline_task(rootdir):
-    #check if subdirectories for baseline task exist or not
-    file_names = sorted(['finger_tapping', 'rest_state', 'affective', 'ping_pong'])
+
+def fcount_baseline_task(rootdir, logging):
+    # check if subdirectories for baseline task exist or not
+    rootdir = rootdir + "/baseline_tasks"
+    file_names = sorted(["finger_tapping", "rest_state", "affective", "ping_pong"])
     count = 0
     for x in sorted(os.listdir(rootdir)):
-        if os.path.isdir(os.path.join(rootdir,x)): 
+        if os.path.isdir(os.path.join(rootdir, x)):
             if file_names[count] in x:
-                print(colored('\n[Status] Sub Directory:', 'blue', attrs=['bold']), colored(os.path.join(rootdir,x), 'green'), u'\N{check mark}')
-                csvread(os.path.join(rootdir,x), os.listdir(os.path.join(rootdir,x)), file_names[count])
+                print(
+                    colored("\n[Status] Sub Directory:", "blue", attrs=["bold"]),
+                    colored(os.path.join(rootdir, x), "green"),
+                    "\N{check mark}",
+                )
+                csvread(
+                    os.path.join(rootdir, x),
+                    os.listdir(os.path.join(rootdir, x)),
+                    file_names[count],
+                    logging,
+                )
             else:
-                print(colored('\n[Error] File does not exist','red'), u'\N{cross mark}')
+                print(colored("\n[Error] File does not exist", "red"), "\N{cross mark}")
+                logging.info(
+                    "\tBaseline_task\tSubfolders_Dont_exist\t{}".format(
+                        file_names[count]
+                    )
+                )
             count += 1

--- a/human_experiments/scripts/inventory_script/utils/run_minecraft_metadata_validation.py
+++ b/human_experiments/scripts/inventory_script/utils/run_minecraft_metadata_validation.py
@@ -1,87 +1,158 @@
-from itertools import count
-import sys  # We use sys.exit() so that all exceptions can properly propogate up and cause the interpreter to exit.
 import os
 import json
-import argparse
 import datetime
 from termcolor import colored
 from pathlib import Path
 
-def check_asist_folder(rootdir):
-    '''
-    asist is usually under exp_*/testbed_logs/
-    '''
-    for path, dir, files in os.walk(rootdir+'testbed_logs'):
-        try:
-            if 'asist_logs' in  str(dir)[1:-1]:
-                print(
-                    colored("\n [Status] Asist folder exists:", "blue", attrs=["bold"]),
-                    colored(dir, "cyan"),
-                )
-                
-                size = sum(p.stat().st_size for p in Path(rootdir + 'testbed_logs').rglob('*'))
-                if size > 1.5 * 1e+9:
-                    print(
-                        colored("\n [Status] Asist folder is of size:", "blue", attrs=["bold"]),
-                        colored(size/(1024*1024*1024), "cyan"),
-                        colored('GB', 'cyan')
-                    )
-                else:
-                    print(
-                        colored("\n [Status] Asist folder has an unexpected size. Please check!", "Red", attrs=["bold"]),
-                        colored(size/(1024*1024*1024), "cyan"),
-                        colored('GB', 'cyan')
-                    )
-        except:
-                print(
-                    colored("[Error] Asist folder does not exist", 'red',attrs=["bold"])
-                )                              
-                
-def check_vocalics(rootdir):
-    '''
-    Vocalics is usually under exp_*/testbed_logs/asist_logs_*/speech_analyzer_agent
-    '''
-    for root, dirs, files in os.walk(rootdir+'testbed_logs'):
-        for name in files:
-            try:
-                if name.endswith((".sql")):
-                    if os.stat(root+'/'+name).st_size!=0:
-                        print(
-                            colored("\n [Status] Voclic features found:", "blue", attrs=["bold"]),
-                            colored(name, "cyan"),
-                        )
-            except:
-                print(
-                    colored("[Error] Voclic features empty or not present", 'red',attrs=["bold"])
-                )    
+training_counter = 0
+saturn_A_counter = 0
+saturn_B_counter = 0
 
-def check_audio(rootdir, x):
-    '''
+
+def check_asist_folder(rootdir, logging):
+    """
+    asist is usually under exp_*/testbed_logs/
+    """
+    if os.path.exists(rootdir + "testbed_logs"):
+        print(
+            colored("\n [Status] Asist folder exists:", "blue", attrs=["bold"]),
+            colored(rootdir + "testbed_logs", "cyan"),
+        )
+        size = sum(p.stat().st_size for p in Path(rootdir + "testbed_logs").rglob("*"))
+        if size > 1.5 * 1e9:
+            print(
+                colored("\n [Status] Asist folder is of size:", "blue", attrs=["bold"]),
+                colored(size / (1024 * 1024 * 1024), "cyan"),
+                colored("GB", "cyan"),
+            )
+        else:
+            print(
+                colored(
+                    "\n [Status] Asist folder has an unexpected size. Please check!",
+                    "red",
+                    attrs=["bold"],
+                ),
+                colored(size / (1024 * 1024 * 1024), "cyan"),
+                colored("GB", "cyan"),
+            )
+            logging.info(
+                "\tASIST_folder\tUnexpected_size\t{}".format(
+                    size / (1024 * 1024 * 1024)
+                )
+            )
+
+    elif os.path.exists(rootdir):
+        for _, dir, files in os.walk(rootdir):
+            """
+            check for the asist_logs_*.tar.gz file
+            """
+            if "asist_logs" in str(files)[1:-1]:
+                print(
+                    colored(
+                        "\n [Warning] Asist tar file exists:", "yellow", attrs=["bold"]
+                    ),
+                    colored(rootdir + "/" + str(files)[1:-1], "cyan"),
+                    colored("Please extract to testbed_logs", "yellow", attrs=["bold"]),
+                )
+                logging.info(
+                    "\tASIST_folder\tExtract_asist_logs_tar_file_to_testbed_logs\t{}".format(
+                        rootdir + "/" + rootdir.split("asist_logs", 1)[0]
+                    )
+                )
+
+    else:
+        print(
+            colored("\n[Error] Asist folder does not exist", "red", attrs=["bold"]),
+            "\N{cross mark}",
+        )
+        logging.info("\tASIST_folder\tDoesnot_exist\t")
+
+
+def check_vocalics(rootdir, logging):
+    """
+    Vocalics is usually under exp_*/testbed_logs/asist_logs_*/speech_analyzer_agent
+    """
+    if os.path.exists(rootdir + "testbed_logs"):
+        for root, dirs, files in os.walk(rootdir + "testbed_logs"):
+            for name in files:
+                try:
+                    if name.endswith((".sql")):
+                        if os.stat(root + "/" + name).st_size != 0:
+                            print(
+                                colored(
+                                    "\n [Status] Voclic features found:",
+                                    "blue",
+                                    attrs=["bold"],
+                                ),
+                                colored(name, "cyan"),
+                            )
+                except:
+                    print(
+                        colored(
+                            "\n [Error] Voclic features empty or not present",
+                            "red",
+                            attrs=["bold"],
+                        ),
+                        "\N{cross mark}",
+                    )
+                    logging.info(
+                        "\tVocalics\tsql_file_not_found\t{}".format(root + "/" + name)
+                    )
+    else:
+        print(
+            colored(
+                "\n[Error]Vocalics not found as Asist folder does not exist",
+                "red",
+                attrs=["bold"],
+            ),
+            "\N{cross mark}",
+        )
+        logging.info("\tVocalics\tDoesnot_exist_as_ASIST_folder_doesnt_exist\t")
+
+
+def check_audio(rootdir, logging, x):
+    """
     Audio file will be under exp_*/lion/audio, exp_*/tiger/audio, exp_*/leopard/audio
-    '''
+    """
     for _, _, files in os.walk(rootdir + x):
         for name in files:
             try:
                 if name.endswith((".wav")):
-                    if os.stat(rootdir+x+'/audio/'+name).st_size!=0:
+                    if os.stat(rootdir + x + "/audio/" + name).st_size != 0:
                         print(
-                            colored("\n [Status] Audio file for", "blue", attrs=["bold"]),
-                            colored(x, 'green', attrs=["bold"]),
-                            colored('found', 'blue', attrs=["bold"]),
+                            colored(
+                                "\n [Status] Audio file for", "blue", attrs=["bold"]
+                            ),
+                            colored(x, "green", attrs=["bold"]),
+                            colored("found", "blue", attrs=["bold"]),
                             colored(name, "cyan"),
                         )
                     else:
                         print(
-                        colored("[Error] Audio file is empty", attrs=["bold"]),
-                        colored(x, "cyan"),
-                        )       
+                            colored(
+                                "[Error] Audio file is empty", "red", attrs=["bold"]
+                            ),
+                            colored(x, "cyan"),
+                            "\N{cross mark}",
+                        )
+                        logging.info(
+                            "\tMinecraft_Audio\tAudio_file_empty\t{}".format(
+                                rootdir + x + "/audio/" + name
+                            )
+                        )
             except:
                 print(
-                colored("[Error] Audio file doesn't exist", attrs=["bold"]),
-                colored(x, "cyan"),
-                )                      
+                    colored("[Error] Audio file doesn't exist", attrs=["bold"]),
+                    colored(x, "cyan"),
+                )
+                logging.info(
+                    "\tMinecraft_Audio\tAudio_file_doesnot_exist\t{}".format(
+                        rootdir + x + "/audio/" + name
+                    )
+                )
 
-def check_time_difference(mission_start, mission_end):
+
+def check_time_difference(mission_start, mission_end, logging, path):
     """
     The timestamps for the start and end of the trial are published in
     ISO-8601 format, which has to be converted into datetime format
@@ -89,20 +160,18 @@ def check_time_difference(mission_start, mission_end):
     find out the time taken by a mission.
     """
     mission_start = (
-        mission_start.split("T")[0]
-        + " "
-        + mission_start.split("T")[1].split("Z")[0]
+        mission_start.split("T")[0] + " " + mission_start.split("T")[1].split("Z")[0]
     )
     mission_end = (
         mission_end.split("T")[0] + " " + mission_end.split("T")[1].split("Z")[0]
     )
 
     print(
-        colored("\n[Status] Mission started at time:", "blue", attrs=["bold"]),
+        colored("\n[Info] Mission started at time:", "blue", attrs=["bold"]),
         mission_start,
     )
     print(
-        colored("\n[Status] Mission ended at time:", "blue", attrs=["bold"]),
+        colored("\n[Info] Mission ended at time:", "blue", attrs=["bold"]),
         mission_end,
     )
 
@@ -110,9 +179,7 @@ def check_time_difference(mission_start, mission_end):
         str(mission_start), "%Y-%m-%d %H:%M:%S.%f"
     )
     mission_start = mission_start.timestamp()
-    mission_end = datetime.datetime.strptime(
-        str(mission_end), "%Y-%m-%d %H:%M:%S.%f"
-    )
+    mission_end = datetime.datetime.strptime(str(mission_end), "%Y-%m-%d %H:%M:%S.%f")
     mission_end = mission_end.timestamp()
     delta = int(float(mission_end) - float(mission_start))
     min, sec = divmod(delta, 60)
@@ -127,41 +194,84 @@ def check_time_difference(mission_start, mission_end):
         )
     else:
         print(
-            colored(
-                "[Error] Timing for mission is off by a large margin", "red"
-            ),
+            colored("\n[Error] Timing for mission is off by a large margin", "red"),
             "\N{cross mark}",
         )
-
-
-def read_subject_id(TrialMessages):
-
-    print(colored("\n[Status] Subject info:", "blue", attrs=["bold"]))
-    try:
-        # Display subject IDs
-        for idx, sub in enumerate(
-            TrialMessages[0]["data"]["metadata"]["trial"]["subjects"]
-        ):
-            print(colored("\t Subect ID", "magenta"), idx, ":", sub)
-        # Display trial name
-        print(
-            colored("\n[Status] Mission name:", "blue", attrs=["bold"]),
-            TrialMessages[0]["data"]["metadata"]["trial"]["name"],
-        )
-    except:
-        # Display subject IDs
-        for idx, sub in enumerate(
-            TrialMessages[0]["data"]["subjects"]
-        ):
-            print(colored("\t Subect ID", "magenta"), idx, ":", sub)        
-        # Display trial name
-        print(
-            colored("\n[Status] Mission name:", "blue", attrs=["bold"]),
-            TrialMessages[0]['data']['experiment_mission'],
+        logging.info(
+            "\tMinecraft\tTime_taken_for_mission_out_of_range\t{}".format(path)
         )
 
 
-def read_metadata_as_json(path):
+def read_subject_id(TrialMessages, logging):
+
+    global training_counter
+    global saturn_A_counter
+    global saturn_B_counter
+
+    print(colored("\n[Status] Minecraft mission info:", "blue", attrs=["bold"]))
+    for i in range(len(TrialMessages)):
+        try:
+            print(
+                colored("\n[Info] Mission name:", "blue", attrs=["bold"]),
+                TrialMessages[i]["data"]["experiment_mission"],
+            )
+
+            """
+            Keep a counter for every mission as sometimes metadata can have multiple trials under same trial ID. 
+            """
+            if TrialMessages[i]["data"]["experiment_mission"] == "Hands-on Training":
+                training_counter += 1
+            if TrialMessages[i]["data"]["experiment_mission"] == "Saturn_A":
+                saturn_A_counter += 1
+            if TrialMessages[i]["data"]["experiment_mission"] == "Saturn_B":
+                saturn_B_counter += 1
+
+            if training_counter > 1:
+                print(
+                    colored(
+                        "\n[Warning] Multiple Hands-on Training missions found",
+                        "blue",
+                        attrs=["bold"],
+                    ),
+                )
+                logging.info("\tMinecraft\tMultiple_Handson_Training_missions_found")
+            elif saturn_A_counter > 1:
+                print(
+                    colored(
+                        "\n[Warning] Multiple Saturn_A missions found",
+                        "blue",
+                        attrs=["bold"],
+                    ),
+                )
+                logging.info("\tMinecraft\tMultiple_Saturn_A_missions_found")
+            elif saturn_B_counter > 1:
+                print(
+                    colored(
+                        "\n[Warning] Multiple Saturn_B missions found",
+                        "blue",
+                        attrs=["bold"],
+                    ),
+                )
+                logging.info("\tMinecraft\tMultiple_Saturn_B_missions_found")
+
+            if training_counter >= 2 or saturn_A_counter >= 2 or saturn_B_counter >= 2:
+                training_counter, saturn_A_counter, saturn_B_counter = 0, 0, 0
+
+            print(
+                colored("\n[Info] Testbed version:", "blue", attrs=["bold"]),
+                TrialMessages[i]["data"]["testbed_version"],
+            )
+
+            print(colored("\n[Info] Subject info:", "blue", attrs=["bold"]))
+            for idx, sub in enumerate(TrialMessages[i]["data"]["subjects"]):
+                print(colored("\t Subect ID", "magenta"), idx, ":", sub)
+            if idx == 2:
+                break
+        except:
+            continue
+
+
+def read_metadata_as_json(path, logging):
     """
     This function reads in a .metadata file, and performs some basic checks,
     prints out the subject IDs, and checks the time difference between the
@@ -189,87 +299,126 @@ def read_metadata_as_json(path):
                 ):
                     if json_message["data"]["mission_state"] == "Start":
                         mission_start = json_message["msg"]["timestamp"]
-                        condition.append('Start')
+                        condition.append("Start")
                     if json_message["data"]["mission_state"] == "Stop":
                         mission_end = json_message["msg"]["timestamp"]
-                        condition.append('Stop')
-                        
+                        condition.append("Stop")
+
                 if len(condition) == 2:
                     continue
-                else: 
-                    '''
+                else:
+                    """
                     There can be issue where the experimentor ends the mission
-                    abruptly, then mission_state wouldn't have stop message. 
-                    Switch to trial message instead and see when the trial 
-                    ended and use that as mission_end. 
-                    '''
-                    if (
-                        json_message["header"]["message_type"] == "trial"
-                        ):
+                    abruptly, then mission_state wouldn't have stop message.
+                    Switch to trial message instead and see when the trial
+                    ended and use that as mission_end.
+                    """
+                    if json_message["header"]["message_type"] == "trial":
+                        if json_message["msg"]["sub_type"] == "start":
+                            print(
+                                colored(
+                                    "\n[Warning] Mission start not found. Using trial start as mission start!",
+                                    "yellow",
+                                )
+                            )
+                            mission_start = json_message["msg"]["timestamp"]
+                            logging.info(
+                                "\tMinecraft\tUsed_trial_start_as_mission_start_not_found\t{}".format(
+                                    path
+                                )
+                            )
+
                         if json_message["msg"]["sub_type"] == "stop":
                             print(
-                            colored("[Warning] Mission end not found. Using trial end as mission end!", "yellow")
+                                colored(
+                                    "\n[Warning] Mission end not found. Using trial end as mission end!",
+                                    "yellow",
+                                )
                             )
                             mission_end = json_message["msg"]["timestamp"]
-                        
+                            logging.info(
+                                "\tMinecraft\tUsed_trial_end_as_mission_end_not_found\t{}".format(
+                                    path
+                                )
+                            )
+
             except:
                 print(
-                    colored("[Error] Cannot read JSON line", "red"),
+                    colored("\n[Error] Cannot read JSON line", "red"),
                     "\N{cross mark}",
                 )
-    read_subject_id(TrialMessages)
-    check_time_difference(mission_start, mission_end)
+                logging.info(
+                    "\tMinecraft\tCannot_read_metadata_as_JSON\t{}".format(path)
+                )
+
+    read_subject_id(TrialMessages, logging)
+    check_time_difference(mission_start, mission_end, logging, path)
 
 
-def checkfile_minecraft(rootdir):
+def checkfile_minecraft(rootdir, logging):
     """
     This function checks if the .metadata file is present under the given path or not. It also checks
     if the .metadata file is empty or not.
     """
-    dir = os.listdir(rootdir)
 
-    if len(dir) == 0:
-        # sometime .DS_Store might be there so the length would be 1
-        print(
-            colored(
-                "\n[Error] Metadata file is missing", "red", attrs=["bold"]
-            ),
-            "\N{cross mark}",
-        )
-    else:
-        for x in os.listdir(rootdir):
-            if x.endswith(".metadata"):
-                # check if .metadata file exists or not
-                print(
-                    colored(
-                        "\n[Status] Metadata File:", "blue", attrs=["bold"]
-                    ),
-                    colored(os.path.join(rootdir, x), "green"),
-                    "\N{check mark}",
-                )
+    rootdir = os.path.join(rootdir, "minecraft")
+    if os.path.exists(rootdir):
+        #check if the minecraft folder exist or not
+        dir = os.listdir(rootdir)
+    
+        if len(dir) == 0:
+            # sometime .DS_Store might be there so the length would be 1
+            print(
+                colored("\n[Error] Metadata file is missing", "red", attrs=["bold"]),
+                "\N{cross mark}",
+            )
+            logging.info("\tMinecraft\tMetadata_missing")
 
-                if os.stat(os.path.join(rootdir, x)).st_size == 0:
-                    # check if .metadata file is empty or not
+        else:
+            for x in os.listdir(rootdir):
+                if x.endswith(".metadata"):
+                    # check if .metadata file exists or not
+                    print(
+                        colored("\n[Status] Metadata File:", "blue", attrs=["bold"]),
+                        colored(os.path.join(rootdir, x), "green"),
+                        "\N{check mark}",
+                    )
+
+                    if os.stat(os.path.join(rootdir, x)).st_size == 0:
+                        # check if .metadata file is empty or not
+                        print(
+                            colored(
+                                "\n[Error] Metadata file is empty",
+                                "red",
+                                attrs=["bold"],
+                            ),
+                            "\N{cross mark}",
+                        )
+                        logging.info(
+                            "\tMinecraft\tMetadata_is_empty\t{}".format(
+                                os.path.join(rootdir, x)
+                            )
+                        )
+                    else:
+                        read_metadata_as_json(os.path.join(rootdir, x), logging)
+
+                elif x.endswith(".DS_Store"):
+                    # The .DS_Store file might be there sometimes
+                    continue
+                else:
                     print(
                         colored(
-                            "\n[Error] Metadata file is empty",
+                            "\n[Error] Metadata file is missing",
                             "red",
                             attrs=["bold"],
                         ),
                         "\N{cross mark}",
                     )
-                else:
-                    read_metadata_as_json(os.path.join(rootdir, x))
-            elif x.endswith(".DS_Store"):
-                # The .DS_Store file might be there sometimes
-                continue
-            else:
-                print(
-                    colored(
-                        "\n[Error] Metadata file is missing",
-                        "red",
-                        attrs=["bold"],
-                    ),
-                    "\N{cross mark}",
-                )
+                    logging.info("\tMinecraft\tMetadata_missing")                                               
 
+    else:
+        print(
+        colored("\n[Error] Minecraft folder is missing", "red", attrs=["bold"]),
+        "\N{cross mark}",
+        )
+        logging.info("\tMinecraft\tMinecraft_folder_missing")      

--- a/human_experiments/scripts/inventory_script/utils/run_pupil_capture_validation.py
+++ b/human_experiments/scripts/inventory_script/utils/run_pupil_capture_validation.py
@@ -1,16 +1,130 @@
 import os
+import os.path
 from termcolor import colored
 
-def check_pupil_recorder(rootdir):
-    for root, dirs, files in os.walk(rootdir):
-        for file in files:
-            try:
-                if file.endswith(".mp4"):
-                    if os.stat(root+'/'+file).st_size!=0:
+pupil_file_list_1 = [
+    "eye1.mp4",
+    "eye0.mp4",
+    "world.mp4",
+    "surfaces.pldata",
+    "world_timestamps.npy",
+    "notify.pldata",
+    "blinks_timestamps.npy",
+    "gaze_timestamps.npy",
+    "notify_timestamps.npy",
+    "user_info.csv",
+    "gaze.pldata",
+    "eye0.intrinsics",
+    "eye1_timestamps.npy",
+    "pupil.pldata",
+    "eye0_timestamps.npy",
+    "info.player.json",
+    "surface_definitions_v01",
+    "surfaces_timestamps.npy",
+    "eye1.intrinsics",
+    "blinks.pldata",
+    "fixations_timestamps.npy",
+    "pupil_timestamps.npy",
+    "world.intrinsics",
+    "fixations.pldata",
+]
+pupil_file_list_2 = [
+    "eye1.mp4.writing",
+    "eye0.mp4.writing",
+    "world.mp4.writing",
+    "surfaces.pldata",
+    "world_timestamps.npy",
+    "notify.pldata",
+    "blinks_timestamps.npy",
+    "gaze_timestamps.npy",
+    "notify_timestamps.npy",
+    "user_info.csv",
+    "gaze.pldata",
+    "eye0.intrinsics",
+    "eye1_timestamps.npy",
+    "pupil.pldata",
+    "eye0_timestamps.npy",
+    "info.player.json",
+    "surface_definitions_v01",
+    "surfaces_timestamps.npy",
+    "eye1.intrinsics",
+    "blinks.pldata",
+    "fixations_timestamps.npy",
+    "pupil_timestamps.npy",
+    "world.intrinsics",
+    "fixations.pldata",
+]
+
+
+def check_pupil_recorder(rootdir_master, logging, imac):
+    rootdir = rootdir_master + imac + "/pupil_recorder/000/"
+    for f1, f2 in zip(pupil_file_list_1, pupil_file_list_2):
+        if os.path.isfile(rootdir + f1) or os.path.isfile(rootdir + f2):
+            if ".writing" in rootdir + f2:
+                # check *.mp4.writing files
+                try:
+                    if os.stat(rootdir + f2).st_size != 0:
                         print(
-                            colored('\n [Status] Mp4 file of pupil capture file found at ', 'blue', attrs=['bold']), 
-                            colored(os.path.join(root, file), 'cyan')
+                            colored(
+                                "\n [Warning] Incomplete Pupil capture file found at ",
+                                "yellow",
+                                attrs=["bold"],
+                            ),
+                            colored(rootdir + f2, "cyan"),
+                        )
+                        logging.info(
+                            "\tPupil_recorder\tFile_didnt_complete_Writing\t{}".format(
+                                rootdir + f2
                             )
-            except:
-                print(
-                    colored('[Error]  Mp4 file of pupil capture file is either empty or not present', 'red', attrs=['bold']),) 
+                        )
+                    else:
+                        print(
+                            colored(
+                                "\n [Error] Incomplete and empty Pupil capture file found at ",
+                                "red",
+                                attrs=["bold"],
+                            ),
+                            colored(rootdir + f2, "cyan"),
+                            "\N{cross mark}",
+                        )
+                        logging.info(
+                            "\tPupil_recorder\tIncomplete_file_found_but_no_data\t{}".format(
+                                rootdir + f2
+                            )
+                        )
+                except:
+                    pass
+            else:
+                # check *.mp4 files
+                if os.stat(rootdir + f1).st_size != 0:
+                    print(
+                        colored(
+                            "\n [Status] Pupil capture file found at ",
+                            "blue",
+                            attrs=["bold"],
+                        ),
+                        colored(rootdir + f1, "cyan"),
+                    )
+                else:
+                    print(
+                        colored(
+                            "\n [Error] Empty Pupil capture file found at ",
+                            "red",
+                            attrs=["bold"],
+                        ),
+                        colored(rootdir + f1, "cyan"),
+                        "\N{cross mark}",
+                    )
+                    logging.info(
+                        "\tPupil_recorder\tFile_found_but_no_data\t{}".format(
+                            rootdir + f1
+                        )
+                    )
+        else:
+            print(
+                colored("\n [Error] Pupil capture file: ", "red", attrs=["bold"]),
+                colored(rootdir + f1, "yellow"),
+                colored("not found! ", "red", attrs=["bold"]),
+                "\N{cross mark}",
+            )
+            logging.info("\tPupil_recorder\tFile_not_found\t{}".format(rootdir + f1))

--- a/human_experiments/scripts/inventory_script/utils/run_xdf_check.py
+++ b/human_experiments/scripts/inventory_script/utils/run_xdf_check.py
@@ -1,16 +1,36 @@
 import os
 from termcolor import colored
 
-def check_xdf(rootdir):
+def check_xdf(rootdir_master, logging, imac):
+    rootdir = rootdir_master + "/" + imac + "/eeg_fnirs_pupil/"
     for root, dirs, files in os.walk(rootdir):
         for file in files:
             try:
                 if file.endswith(".xdf"):
-                    if os.stat(root+'/'+file).st_size!=0:
+                    if os.stat(root + "/" + file).st_size != 0:
                         print(
-                            colored('\n [Status] xdf file found at ', 'blue', attrs=['bold']), 
-                            colored(os.path.join(root, file), 'cyan')
+                            colored(
+                                "\n [Status] xdf file found at ", "blue", attrs=["bold"]
+                            ),
+                            colored(os.path.join(root, file), "cyan"),
+                        )
+                    else:
+                        print(
+                            colored(
+                                "[Error] xdf file found but is empty ",
+                                "red",
+                                attrs=["bold"],
+                            ),
+                        )
+                        logging.info(
+                            "\XDF_file\File_found_but_empty\t{}".format(
+                                os.path.join(root, file)
                             )
+                        )
             except:
                 print(
-                    colored('[Error] xdf file is either empty or not present', 'red', attrs=['bold']),) 
+                    colored("[Error] xdf file is not present", "red", attrs=["bold"]),
+                )
+                logging.info(
+                    "\XDF_file\tFile_not_found\t{}".format(os.path.join(root, file))
+                )


### PR DESCRIPTION
**Minor updates:**
1. Hardcoding paths to folders like Minecraft, baseline_task, etc to avoid unnecessary os.walk(), hence saving search time. 
2. Hardcoding pupil capture file names and check if those files exist or not. 
3. Condition to handle multiple multiple trials under same trial ID for Minecraft metadata and report it as a warning. 

**Major updates:**
1. Using logging package to log info about the missing data to specific folder '<user defined path>/sanity_check/exp_*'
4. Added a wrapper script that loops across all files, passes it through the inventory script and logs info about missing data if any. 