### PR TITLE
Fix fnirs and eeg on database

### DIFF
--- a/human_experiments/datasette_interface/label_data.py
+++ b/human_experiments/datasette_interface/label_data.py
@@ -5,13 +5,11 @@ from entity.task.ping_pong_competitive_task_observation import PingPongCompetiti
 from entity.task.ping_pong_cooperative_task_observation import PingPongCooperativeTaskObservation
 from entity.task.minecraft_task import MinecraftMission
 
-from sqlalchemy.orm import Session
-from sqlalchemy import Index
 from sqlalchemy import func
 from sqlalchemy import delete
 from sqlalchemy import update
 
-from logging import info, error
+from logging import error
 
 
 def label_signals_with_task(signal_modality_class, task, station, participant_id, start_timestamp, stop_timestamp,
@@ -143,8 +141,8 @@ def label_minecraft_data(signal_modality_class, group_session, station, particip
     else:
         raise ValueError(f"Bad task: {task}!")
 
-    start_timestamp, stop_timestamp = database_session.query(MinecraftMission.start_timestamp_unix,
-                                                             MinecraftMission.stop_timestamp_unix).filter(
+    start_timestamp, stop_timestamp = database_session.query(MinecraftMission.mission_start_timestamp_unix,
+                                                             MinecraftMission.mission_stop_timestamp_unix).filter(
         MinecraftMission.group_session_id == group_session,
         MinecraftMission.name == mission,
     ).first()

--- a/human_experiments/datasette_interface/process_eeg_raw_data.py
+++ b/human_experiments/datasette_interface/process_eeg_raw_data.py
@@ -47,7 +47,8 @@ def process_eeg_raw_data(database_engine, override):
                     device_id_to_station_map[eeg_device.group_session_id][eeg_device.device_id] = eeg_device.station_id
 
     insert_raw_unlabeled_data(database_engine, override, EEGRaw, "eeg", "EEG", get_channel_names_from_xdf_stream,
-                              partial(get_station_from_xdf_stream, device_id_to_station_map=device_id_to_station_map))
+                              partial(get_station_from_xdf_stream, device_id_to_station_map=device_id_to_station_map),
+                              lambda x: x * 1-6)  # From micro-volt to volt
     create_indices(database_engine, not override, EEGRaw, "eeg")
     label_data(database_engine, override, EEGRaw, "eeg")
 

--- a/human_experiments/datasette_interface/process_fnirs_raw_data.py
+++ b/human_experiments/datasette_interface/process_fnirs_raw_data.py
@@ -23,7 +23,7 @@ logging.basicConfig(
 
 def get_channel_names_from_xdf_stream(stream):
     return [channel["custom_name"][0].lower().replace("-", "_") + channel["type"][0][-4:].lower() for channel in
-                stream["info"]["desc"][0]["channels"][0]["channel"][41:]]
+            stream["info"]["desc"][0]["channels"][0]["channel"][41:]]
 
 
 def get_station_from_xdf_stream(group_session, stream):
@@ -33,7 +33,7 @@ def get_station_from_xdf_stream(group_session, stream):
 def process_fnirs_raw_data(database_engine, override):
     info("Processing FNIRSRaw data.")
     insert_raw_unlabeled_data(database_engine, override, FNIRSRaw, "fnirs", "NIRS", get_channel_names_from_xdf_stream,
-                              get_station_from_xdf_stream)
+                              get_station_from_xdf_stream, lambda x: x[41:])
     create_indices(database_engine, not override, FNIRSRaw, "fnirs")
     label_data(database_engine, override, FNIRSRaw, "fnirs")
 

--- a/human_experiments/datasette_interface/process_raw_signals.py
+++ b/human_experiments/datasette_interface/process_raw_signals.py
@@ -21,7 +21,7 @@ from utils import (
 
 def insert_raw_unlabeled_data(database_engine, override, signal_modality_class, modality_name, xdf_signal_type,
                               channel_from_xdf_parsing_fn, station_from_xdf_v2_parsing_fn,
-                              slice_series_fn: lambda x: x):
+                              slice_series_fn=lambda x: x):
     info(f"Inserting unlabeled data.")
     with cd("/tomcat/data/raw/LangLab/experiments/study_3_pilot/group"):
         directories_to_process = [


### PR DESCRIPTION
This PR fixes a problem with fnirs that was reading from the wrong channels in the xdf stream and it multiplies eeg signals with 1e-6 to convert them from microvolts to volts.