### PR TITLE
Updates to docker-compose.prod.yml and metadata.yml

### DIFF
--- a/human_experiments/datasette_interface/docker-compose.prod.yml
+++ b/human_experiments/datasette_interface/docker-compose.prod.yml
@@ -17,9 +17,9 @@ services:
         --metadata /repo/metadata.yml
         --template-dir /repo/templates
         --plugins-dir /repo/plugins
-        --inspect-file /repo/inspect-data.json
+        --inspect-file /repo/inspect_file.json
         --static assets:/repo/static
         --setting sql_time_limit_ms 10000
-        --setting facet_time_limit_ms 10000 
+        --setting facet_time_limit_ms 10000
         --setting num_sql_threads 10
         --setting max_csv_mb 12000

--- a/human_experiments/datasette_interface/metadata.yml
+++ b/human_experiments/datasette_interface/metadata.yml
@@ -124,12 +124,14 @@ databases:
 
             group_session:
                 description: Table with group session IDs.
+                label_column: id
                 columns:
                     id: >
                         Group session ID. Format: `exp_YYYY_MM_DD_HH`.
 
             mission:
                 description: Metadata about the Minecraft missions.
+                label_column: id
                 columns:
                     id: The unique ID of the mission.
                     group_session_id: The group session that the mission was a part of.
@@ -152,6 +154,7 @@ databases:
 
             participant:
                 description: Table with participant IDs.
+                label_column: id
                 columns:
                     id: >
                         Participant ID.
@@ -229,11 +232,13 @@ databases:
                     competitive ping pong task, when an experimenter steps in
                     to play against the participant seated at the 'leopard'
                     station.
+                label_column: id
                 columns:
                     id: Station ID.
 
             task:
                 description: The different tasks that take place during a group session.
+                label_column: id
                 columns:
                     id: Task ID.
 


### PR DESCRIPTION
This PR changes the name of the inspect file in `docker-compose.prod.yml` to `inspect_file.json`, and specifies label columns in `metadata.yml` for better displaying of foreign key relationships in the Datasette interface.