### PR TITLE
Launch CLC training video with Uberscript

### DIFF
--- a/human_experiments/scripts/play_instructive_video
+++ b/human_experiments/scripts/play_instructive_video
@@ -3,15 +3,21 @@
 set -u
 
 if [[ -z ${1+x} ]]; then
+  VIDEO_FILE="video.mp4"
+  PADDING=""
+elif [[ -z ${2+x} ]]; then
+  VIDEO_FILE=$1
   PADDING=""
 else
-  PADDING=$1
+  VIDEO_FILE=$1
+  PADDING=$2
 fi
 
 __play_on_client() {
   local client_name=$1
   local client_address=$2
-  local padding=$3
+  local video_file=$3
+  local padding=$4
 
   if [[ $ALL -ne 1 ]]; then
     yes_no_question "${padding}Do you want to play the video on ${EMPH}$client_name${NC}?"
@@ -19,11 +25,11 @@ __play_on_client() {
     padding="$padding "
   fi
   if [[ $ALL -eq 1 ]] || [[ $ans -eq 0 ]]; then
-    echo -e "${padding}Playing the ${EMPH}video${NC} on ${EMPH}$client_name${NC}..."
+    echo -e "${padding}Playing the ${EMPH}$video_file${NC} on ${EMPH}$client_name${NC}..."
 
     # If the location of the video in the client machine changes, make sure to
     # update the applescript below.
-    local command="open \$HOME/resources/tomcat/video.mp4"
+    local command="open \$HOME/resources/tomcat/$video_file"
     # shellcheck disable=SC2029
     if ssh "$EXPERIMENT_USER@$client_address" "$command" >/dev/null; then
       echo -e "${padding} ${EMPH}Video${GREEN} opened successfully.${NC}"
@@ -34,13 +40,14 @@ __play_on_client() {
 }
 
 __play_videos() {
-  local padding=$1
+  local video_file=$1
+  local padding=$2
 
-  echo -e "${padding}Playing the ${EMPH}videos${NC}..."
+  echo -e "${padding}Playing the ${EMPH}$video_file${NC}..."
 
-  __play_on_client "lion" "lion.local" "$PADDING "
-  __play_on_client "tiger" "tiger.local" "$PADDING "
-  __play_on_client "leopard" "leopard.local" "$PADDING "
+  __play_on_client "lion" "lion.local" "$video_file" "$PADDING "
+  __play_on_client "tiger" "tiger.local" "$video_file" "$PADDING "
+  __play_on_client "leopard" "leopard.local" "$video_file" "$PADDING "
 }
 
-__play_videos "$PADDING"
+__play_videos "$VIDEO_FILE" "$PADDING"

--- a/human_experiments/scripts/run_experiment
+++ b/human_experiments/scripts/run_experiment
@@ -49,34 +49,35 @@ __help() {
   echo "[6]:  Open the Client Map"
   echo "[7]:  Open the Eye-tracker program"
   echo "[8]:  Open the Instructive Video"
-  echo "[9]:  Start the Lab Recorder"
-  echo "[10]: Start recording from the Eye-tracker"
-  echo "[11]: Start Face and Screen recordings"
-  echo " [11.1]: Face"
-  echo " [11.2]: Screen"
-  echo "[12]: Start the Baseline Tasks"
-  echo "[13]: End Block 1"
-  echo " [13.1]: Stop Face recordings"
-  echo " [13.2]: Stop Screen recordings"
-  echo " [13.3]: Stop Eye-tracker recordings"
-  echo " [13.4]: Stop LabRecorder"
+  echo "[9]:  Open the CLC Training Video"
+  echo "[10]: Start the Lab Recorder"
+  echo "[11]: Start recording from the Eye-tracker"
+  echo "[12]: Start Face and Screen recordings"
+  echo " [12.1]: Face"
+  echo " [12.2]: Screen"
+  echo "[13]: Start the Baseline Tasks"
+  echo "[14]: End Block 1"
+  echo " [14.1]: Stop Face recordings"
+  echo " [14.2]: Stop Screen recordings"
+  echo " [14.3]: Stop Eye-tracker recordings"
+  echo " [14.4]: Stop LabRecorder"
   echo -e "${BLACK}${ON_YELLOW}Block 2                                  ${NC}"
-  echo "[14]: Start the Lab Recorder"
-  echo "[15]: Start Minecraft Watcher"
-  echo " [15.1]: Start Data Watcher"
-  echo " [15.2]: Start Trial ID Watcher"
-  echo "[16]: Start the Audio, Face and Screen recordings"
-  echo " [16.1]: Audio"
-  echo " [16.2]: Face"
-  echo " [16.3]: Screen"
-  echo "[17]: Start Eye-tracker recordings"
-  echo "[18]: Stop Eye-tracker recordings"
-  echo "[19]: Open the Final Survey"
-  echo "[20]: Stop Audio, Face and Screen recordings"
-  echo "[21]: Stop the Lab Recorder"
-  echo "[22]: Exports Minecraft data"
-  echo "[23]: Extracts Testbed Logs"
-  echo "[24]: End the experiment (close remaining applications)"
+  echo "[15]: Start the Lab Recorder"
+  echo "[16]: Start Minecraft Watcher"
+  echo " [16.1]: Start Data Watcher"
+  echo " [16.2]: Start Trial ID Watcher"
+  echo "[17]: Start the Audio, Face and Screen recordings"
+  echo " [17.1]: Audio"
+  echo " [17.2]: Face"
+  echo " [17.3]: Screen"
+  echo "[18]: Start Eye-tracker recordings"
+  echo "[19]: Stop Eye-tracker recordings"
+  echo "[20]: Open the Final Survey"
+  echo "[21]: Stop Audio, Face and Screen recordings"
+  echo "[22]: Stop the Lab Recorder"
+  echo "[23]: Exports Minecraft data"
+  echo "[24]: Extracts Testbed Logs"
+  echo "[25]: End the experiment (close remaining applications)"
   echo
   echo "Syntax: run_experiment [-h|a]"
   echo "options:"
@@ -225,16 +226,23 @@ fi
 if [[ $GOTO -le 8 ]]; then
   echo " "
   if yes_no_question "[8] Do you want to play the ${EMPH}Instructive Video${NC}?"; then
-    source play_instructive_video " "
+    source play_instructive_video "minecraft_instruction_video.mp4" " "
+  fi
+fi
+
+if [[ $GOTO -le 9 ]]; then
+  echo " "
+  if yes_no_question "[9] Do you want to play the ${EMPH}CLC Training Video${NC}?"; then
+    source play_instructive_video "clc_training_video.mp4" " "
   fi
 fi
 
 echo ""
 echo -e "${BLACK}${ON_CYAN}Wait for Okay from the Social Science team.${NC}"
 
-if [[ $GOTO -le 9 ]]; then
+if [[ $GOTO -le 10 ]]; then
   echo " "
-  if yes_no_question "[9] Do you want to start ${EMPH}Lab Recorder${NC}?"; then
+  if yes_no_question "[10] Do you want to start ${EMPH}Lab Recorder${NC}?"; then
     source start_lab_recorder " "
   fi
 fi
@@ -242,47 +250,47 @@ fi
 echo ""
 echo -e "${BLACK}${ON_CYAN}Make sure to press the OK button on Lab Recorder to record anyway before proceeding.${NC}"
 
-if [[ $GOTO -le 10 ]]; then
-  echo " "
-  if yes_no_question "[10] Do you want to start recording from the ${EMPH}Eye-tracker${NC} program?"; then
-    source pupil_recording "start" " "
-  fi
-fi
-
 if [[ $GOTO -le 11 ]]; then
   echo " "
-  if yes_no_question "[11] Do you want to start ${EMPH}Face and Screen${NC} recordings?"; then
-    source image_monitoring "start" "  "
-    if yes_no_question " [11.1] Do you want to start ${EMPH}Face${NC} recordings?"; then
-      source video_recording "webcam" "start" "  "
-    fi
-    if yes_no_question " [11.2] Do you want to start ${EMPH}Screen${NC} recordings?"; then
-      source video_recording "screen" "start" "  "
-    fi
+  if yes_no_question "[11] Do you want to start recording from the ${EMPH}Eye-tracker${NC} program?"; then
+    source pupil_recording "start" " "
   fi
 fi
 
 if [[ $GOTO -le 12 ]]; then
   echo " "
-  if yes_no_question "[12] Do you want to start the ${EMPH}Baseline Tasks${NC}?"; then
-    source start_baseline_tasks " "
+  if yes_no_question "[12] Do you want to start ${EMPH}Face and Screen${NC} recordings?"; then
+    source image_monitoring "start" "  "
+    if yes_no_question " [12.1] Do you want to start ${EMPH}Face${NC} recordings?"; then
+      source video_recording "webcam" "start" "  "
+    fi
+    if yes_no_question " [12.2] Do you want to start ${EMPH}Screen${NC} recordings?"; then
+      source video_recording "screen" "start" "  "
+    fi
   fi
 fi
 
 if [[ $GOTO -le 13 ]]; then
   echo " "
-  if yes_no_question "[13] Do you want to finish ${EMPH}Block 1${NC}?"; then
-    if yes_no_question " [13.1] Do you want to stop ${EMPH}Face${NC} recordings?"; then
+  if yes_no_question "[13] Do you want to start the ${EMPH}Baseline Tasks${NC}?"; then
+    source start_baseline_tasks " "
+  fi
+fi
+
+if [[ $GOTO -le 14 ]]; then
+  echo " "
+  if yes_no_question "[14] Do you want to finish ${EMPH}Block 1${NC}?"; then
+    if yes_no_question " [14.1] Do you want to stop ${EMPH}Face${NC} recordings?"; then
       source video_recording "webcam" "stop" " "
     fi
-    if yes_no_question " [13.2] Do you want to stop ${EMPH}Screen${NC} recordings?"; then
+    if yes_no_question " [14.2] Do you want to stop ${EMPH}Screen${NC} recordings?"; then
       source video_recording "screen" "stop" "  "
     fi
     source image_monitoring "stop" "  "
-    if yes_no_question " [13.3] Do you want to stop recording from the ${EMPH}Eye-tracker${NC} program?"; then
+    if yes_no_question " [14.3] Do you want to stop recording from the ${EMPH}Eye-tracker${NC} program?"; then
       source pupil_recording "stop" "  "
     fi
-    if yes_no_question " [13.4] Do you want to stop ${EMPH}LabRecorder${NC} and kill its instances on CAT?"; then
+    if yes_no_question " [14.4] Do you want to stop ${EMPH}LabRecorder${NC} and kill its instances on CAT?"; then
       source stop_lab_recorder
     fi
   fi
@@ -294,9 +302,9 @@ export EXPERIMENT_BLOCK=2
 echo ""
 echo -e "${BLACK}${ON_YELLOW}Block 2                                    ${NC}"
 
-if [[ $GOTO -le 14 ]]; then
+if [[ $GOTO -le 15 ]]; then
   echo " "
-  if yes_no_question "[14] Do you want to start ${EMPH}Lab Recorder${NC}?"; then
+  if yes_no_question "[15] Do you want to start ${EMPH}Lab Recorder${NC}?"; then
     source start_lab_recorder " "
   fi
 fi
@@ -304,38 +312,38 @@ fi
 echo ""
 echo -e "${BLACK}${ON_CYAN}Make sure to press the OK button on Lab Recorder to record anyway before proceeding.${NC}"
 
-if [[ $GOTO -le 15 ]]; then
-  echo " "
-  if yes_no_question "[15] Do you want to start the ${EMPH}Minecraft Watcher${NC}?"; then
-    echo -e "${YELLOW} Watchers will be closed if the Uber Script is interrupted. Make sure to start them again if needed.${NC}"
-    if yes_no_question " [15.1] Do you want to start the ${EMPH}Data Watcher${NC}?"; then
-      source minecraft_data_watcher "start" "  "
-    fi
-    if yes_no_question " [15.2] Do you want to start the ${EMPH}Trial ID Watcher${NC}?"; then
-      source minecraft_trial_watcher "start" "  "
-    fi
-  fi
-fi
-
 if [[ $GOTO -le 16 ]]; then
   echo " "
-  if yes_no_question "[16] Do you want to start ${EMPH}Audio, Face and Screen${NC} recordings?"; then
-    source image_monitoring "start" "  "
-    if yes_no_question " [16.1] Do you want to start ${EMPH}Audio${NC} recordings?"; then
-      source audio_recording "start" "  "
+  if yes_no_question "[16] Do you want to start the ${EMPH}Minecraft Watcher${NC}?"; then
+    echo -e "${YELLOW} Watchers will be closed if the Uber Script is interrupted. Make sure to start them again if needed.${NC}"
+    if yes_no_question " [16.1] Do you want to start the ${EMPH}Data Watcher${NC}?"; then
+      source minecraft_data_watcher "start" "  "
     fi
-    if yes_no_question " [16.2] Do you want to start ${EMPH}Face${NC} recordings?"; then
-      source video_recording "webcam" "start" "  "
-    fi
-    if yes_no_question " [16.3] Do you want to start ${EMPH}Screen${NC} recordings?"; then
-      source video_recording "screen" "start" "  "
+    if yes_no_question " [16.2] Do you want to start the ${EMPH}Trial ID Watcher${NC}?"; then
+      source minecraft_trial_watcher "start" "  "
     fi
   fi
 fi
 
 if [[ $GOTO -le 17 ]]; then
   echo " "
-  if yes_no_question "[17] Do you want to start recording from the ${EMPH}Eye-tracker${NC} program?"; then
+  if yes_no_question "[17] Do you want to start ${EMPH}Audio, Face and Screen${NC} recordings?"; then
+    source image_monitoring "start" "  "
+    if yes_no_question " [17.1] Do you want to start ${EMPH}Audio${NC} recordings?"; then
+      source audio_recording "start" "  "
+    fi
+    if yes_no_question " [17.2] Do you want to start ${EMPH}Face${NC} recordings?"; then
+      source video_recording "webcam" "start" "  "
+    fi
+    if yes_no_question " [17.3] Do you want to start ${EMPH}Screen${NC} recordings?"; then
+      source video_recording "screen" "start" "  "
+    fi
+  fi
+fi
+
+if [[ $GOTO -le 18 ]]; then
+  echo " "
+  if yes_no_question "[18] Do you want to start recording from the ${EMPH}Eye-tracker${NC} program?"; then
     source pupil_recording "start" " "
   fi
 fi
@@ -343,54 +351,54 @@ fi
 echo ""
 echo -e "${BLACK}${ON_CYAN}Wait for the end of the Minecraft missions.${NC}"
 
-if [[ $GOTO -le 18 ]]; then
+if [[ $GOTO -le 19 ]]; then
   echo " "
-  if yes_no_question "[18] Do you want to stop recording and close the ${EMPH}Eye-tracker${NC} program?"; then
+  if yes_no_question "[19] Do you want to stop recording and close the ${EMPH}Eye-tracker${NC} program?"; then
     source pupil_recording "stop" " "
     source pupil_recording "close" " "
   fi
 fi
 
-if [[ $GOTO -le 19 ]]; then
+if [[ $GOTO -le 20 ]]; then
   echo " "
-  if yes_no_question "[19] Do you want to open the ${EMPH}Final Survey${NC}?"; then
+  if yes_no_question "[20] Do you want to open the ${EMPH}Final Survey${NC}?"; then
     source open_final_survey " "
   fi
 fi
 
-if [[ $GOTO -le 20 ]]; then
+if [[ $GOTO -le 21 ]]; then
   echo " "
-  if yes_no_question "[20] Do you want to stop ${EMPH}Audio, Face and Screen${NC} recordings?"; then
-    if yes_no_question " [20.1] Do you want to stop ${EMPH}Audio${NC} recordings?"; then
+  if yes_no_question "[21] Do you want to stop ${EMPH}Audio, Face and Screen${NC} recordings?"; then
+    if yes_no_question " [21.1] Do you want to stop ${EMPH}Audio${NC} recordings?"; then
       source audio_recording "stop" "  "
     fi
-    if yes_no_question " [20.2] Do you want to stop ${EMPH}Face${NC} recordings?"; then
+    if yes_no_question " [21.2] Do you want to stop ${EMPH}Face${NC} recordings?"; then
       source video_recording "webcam" "stop" "  "
     fi
-    if yes_no_question " [20.3] Do you want to stop ${EMPH}Screen${NC} recordings?"; then
+    if yes_no_question " [21.3] Do you want to stop ${EMPH}Screen${NC} recordings?"; then
       source video_recording "screen" "stop" "  "
     fi
     source image_monitoring "stop" "  "
   fi
 fi
 
-if [[ $GOTO -le 21 ]]; then
-  echo " "
-  if yes_no_question "[21] Do you want to stop ${EMPH}LabRecorder${NC} and kill its instances on CAT?"; then
-    source stop_lab_recorder
-  fi
-fi
-
 if [[ $GOTO -le 22 ]]; then
   echo " "
-  if yes_no_question "[22] Do you want to export ${EMPH}Minecraft data${NC} for all trials in the experiment?"; then
-    source export_minecraft_data " "
+  if yes_no_question "[22] Do you want to stop ${EMPH}LabRecorder${NC} and kill its instances on CAT?"; then
+    source stop_lab_recorder
   fi
 fi
 
 if [[ $GOTO -le 23 ]]; then
   echo " "
-  if yes_no_question "[23] Do you want to extract ${EMPH}Testbed logs${NC}?"; then
+  if yes_no_question "[23] Do you want to export ${EMPH}Minecraft data${NC} for all trials in the experiment?"; then
+    source export_minecraft_data " "
+  fi
+fi
+
+if [[ $GOTO -le 24 ]]; then
+  echo " "
+  if yes_no_question "[24] Do you want to extract ${EMPH}Testbed logs${NC}?"; then
     source extract_testbed_logs " "
   fi
 fi
@@ -398,9 +406,9 @@ fi
 echo ""
 echo -e "${BLACK}${ON_CYAN}Wait for the participants to fill up the surveys.${NC}"
 
-if [[ $GOTO -le 24 ]]; then
+if [[ $GOTO -le 25 ]]; then
   echo " "
-  text="[24] Type [${EMPH}quit${NC}] to end the experiment and close remaining applications and processes: "
+  text="[25] Type [${EMPH}quit${NC}] to end the experiment and close remaining applications and processes: "
   wait_for_key "$text" "quit"
   source end_experiment " "
 


### PR DESCRIPTION
- Modify the `play_instructive_video` program to allow specifying which video to launch on the iMacs.
- Modify the uberscript to launch Minecraft instruction video under a more specific name: `minecraft_instruction_video.mp4`
- Add another step in the uberscript to launch CLC training video: `clc_training_video.mp4`