### PR TITLE
Cap datasette prod container log at 5x50MB

### DIFF
--- a/human_experiments/datasette_interface/docker-compose.prod.yml
+++ b/human_experiments/datasette_interface/docker-compose.prod.yml
@@ -6,6 +6,11 @@ services:
   datasette:
     image: datasette-with-plugins
     restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     ports:
         - "8001:8001"
     volumes:


### PR DESCRIPTION
The container used the default json-file driver with no size limit, so its log grew unbounded (the crawler traffic made this acute). Add a logging block capping it to 5 rotated files of 50MB. Applies on container recreate.